### PR TITLE
S16 HHHL ∧ wick formula backtest (research only)

### DIFF
--- a/goldpetal/backtest_s16_hhhl_wick.py
+++ b/goldpetal/backtest_s16_hhhl_wick.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Backtest the one S16 formula: HH/LL AND wick, same-candle FLIP.
+
+Research only. Do not paper or live-enable until a 100-lot + fees row is picked.
+
+  python3 backtest_s16_hhhl_wick.py --db data/ticks.db --lots 100 --session --fees
+  ./venv/bin/python backtest_s16_hhhl_wick.py --from-angel --tf 30m,1h,1d --from 2026-08-02
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from backtest_hhhl_candles import (
+    TIMEFRAMES,
+    Candle,
+    TfResult,
+    make_charge_cfg,
+    print_by_day,
+    write_outputs,
+)
+from backtest_wick_candles import (
+    build_ohlc_candles,
+    load_ltp_rows,
+    print_wick_summary,
+)
+from s16_hhhl_wick import FORMULA, simulate_s16, walk_candles
+
+IST = ZoneInfo("Asia/Kolkata")
+DEFAULT_TICK_TFS = ",".join(n for n, _ in TIMEFRAMES)
+
+
+def candles_from_dicts(rows: list[dict[str, Any]]) -> list[Candle]:
+    out: list[Candle] = []
+    for r in rows:
+        t = str(r["time"]).replace("T", " ")[:19]
+        out.append(
+            Candle(
+                time=t,
+                open=float(r["open"]),
+                high=float(r["high"]),
+                low=float(r["low"]),
+                close=float(r["close"]),
+            )
+        )
+    return out
+
+
+def write_walk_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "time",
+        "open",
+        "high",
+        "low",
+        "close",
+        "prev_high",
+        "prev_low",
+        "upper",
+        "lower",
+        "hhhl",
+        "wick",
+        "rule",
+        "side",
+        "action",
+        "pos_before",
+        "pos_after",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        w.writerows(rows)
+
+
+def _parse_tick_tfs(raw: str) -> list[tuple[str, int]]:
+    by = {n: m for n, m in TIMEFRAMES}
+    out: list[tuple[str, int]] = []
+    for name in (x.strip().lower() for x in raw.split(",") if x.strip()):
+        if name == "30":
+            name = "30m"
+        if name in {"d", "day", "daily"}:
+            name = "1d"
+        if name not in by:
+            raise SystemExit(f"unknown tf {name!r}. have: {', '.join(by)}")
+        out.append((name, by[name]))
+    if not out:
+        raise SystemExit("no timeframes")
+    return out
+
+
+def run_from_ticks(
+    db: Path,
+    *,
+    lots: float,
+    fees: bool,
+    session_filter: bool,
+    tfs: list[tuple[str, int]],
+    drop_last: bool,
+    out_dir: Path,
+    print_bars_tf: str | None,
+) -> list[TfResult]:
+    rows = load_ltp_rows(db)
+    if not rows:
+        raise SystemExit(f"no ticks in {db}")
+    cfg = make_charge_cfg(fees=fees, lots=lots)
+    results: list[TfResult] = []
+    for name, minutes in tfs:
+        candles = build_ohlc_candles(rows, minutes)
+        if drop_last and len(candles) >= 2:
+            candles = candles[:-1]
+        use_session = session_filter and name != "1d"
+        r = simulate_s16(
+            candles,
+            tf=f"{name}:s16",
+            lots=lots,
+            fees=fees,
+            session_filter=use_session,
+            charge_cfg=cfg,
+        )
+        results.append(r)
+        walk = walk_candles(candles)
+        write_walk_csv(out_dir / f"{name}_walk.csv", walk)
+        if print_bars_tf == name:
+            print(flush=True)
+            print(f"=== {name} bars (finished) ===", flush=True)
+            for row in walk:
+                print(
+                    f"{row['time']:<22} O={row['open']:.1f} H={row['high']:.1f} "
+                    f"L={row['low']:.1f} C={row['close']:.1f}  "
+                    f"U={row['upper']:.1f} Lw={row['lower']:.1f}  "
+                    f"hhhl={row['hhhl']:<5} wick={row['wick']:<5}  "
+                    f"{row['rule']:<32} → {str(row['side']).upper():<5}  "
+                    f"{row['action']:<5}  {row['pos_before']}→{row['pos_after']}",
+                    flush=True,
+                )
+    return results
+
+
+def run_from_angel(
+    *,
+    lots: float,
+    fees: bool,
+    session_filter: bool,
+    tfs: list[str],
+    date_from: str,
+    date_to: str,
+    out_dir: Path,
+    print_bars_tf: str | None,
+) -> list[TfResult]:
+    from explain_s14_candles import (
+        ANGEL_INTERVAL,
+        bar_is_finished,
+        fetch_angel_candles,
+        in_session_dt,
+        parse_bar_ts,
+        reexec_with_bot_python,
+    )
+    from auth import login
+    from symbols import find_goldpetal_futures
+
+    reexec_with_bot_python()
+    start = datetime.strptime(date_from, "%Y-%m-%d").replace(tzinfo=IST)
+    if date_to:
+        end = datetime.strptime(date_to, "%Y-%m-%d").replace(
+            hour=23, minute=30, tzinfo=IST
+        )
+    else:
+        end = datetime.now(IST)
+    contract = find_goldpetal_futures()
+    token = str(contract["token"])
+    symbol = str(contract["symbol"])
+    print(
+        f"contract {symbol} token={token} expiry={contract.get('expiry', '-')}",
+        flush=True,
+    )
+    api = login().api
+    now = datetime.now(IST)
+    cfg = make_charge_cfg(fees=fees, lots=lots)
+    results: list[TfResult] = []
+    for tf in tfs:
+        raw = fetch_angel_candles(
+            api,
+            token=token,
+            interval=ANGEL_INTERVAL[tf],
+            start=start,
+            end=end,
+            exchange=str(contract.get("exchange") or "MCX"),
+        )
+        if session_filter and tf != "1d":
+            raw = [b for b in raw if in_session_dt(parse_bar_ts(b["time"]), tf=tf)]
+        raw = [b for b in raw if bar_is_finished(b["time"], tf, now)]
+        candles = candles_from_dicts(raw)
+        r = simulate_s16(
+            candles,
+            tf=f"{tf}:s16",
+            lots=lots,
+            fees=fees,
+            session_filter=False,
+            charge_cfg=cfg,
+        )
+        results.append(r)
+        walk = walk_candles(candles)
+        write_walk_csv(out_dir / f"{tf}_{symbol}.csv", walk)
+        if print_bars_tf == tf:
+            print(flush=True)
+            print(f"=== {tf} {symbol} ===", flush=True)
+            for row in walk:
+                print(
+                    f"{row['time']:<22} {row['rule']:<32} → "
+                    f"{str(row['side']).upper():<5} {row['action']}",
+                    flush=True,
+                )
+    return results
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--db", type=Path, default=Path("data/ticks.db"))
+    ap.add_argument("--from-angel", action="store_true")
+    ap.add_argument("--tf", default="")
+    ap.add_argument("--from", dest="date_from", default="2026-08-02")
+    ap.add_argument("--to", dest="date_to", default="")
+    ap.add_argument("--lots", type=float, default=100.0)
+    ap.add_argument("--fees", action="store_true", default=True)
+    ap.add_argument("--no-fees", action="store_true")
+    ap.add_argument("--session", action="store_true", default=True)
+    ap.add_argument("--no-session", action="store_true")
+    ap.add_argument("--keep-last", action="store_true", help="keep still-forming last tick bar")
+    ap.add_argument("--print-bars", default="30m", help="print this TF's bars (or '')")
+    ap.add_argument("--out", type=Path, default=Path("data/backtests/s16_hhhl_wick"))
+    args = ap.parse_args()
+    fees = bool(args.fees) and not bool(args.no_fees)
+    session_filter = bool(args.session) and not bool(args.no_session)
+    print_bars_tf = (args.print_bars or "").strip().lower() or None
+    if print_bars_tf == "30":
+        print_bars_tf = "30m"
+
+    print(FORMULA, flush=True)
+    print(
+        f"lots={args.lots:g}  fees={fees}  session={session_filter}  "
+        f"source={'Angel' if args.from_angel else args.db}",
+        flush=True,
+    )
+
+    if args.from_angel:
+        from explain_s14_candles import ANGEL_INTERVAL, _parse_tfs
+
+        tfs = _parse_tfs(args.tf or "30m,1h,1d")
+        results = run_from_angel(
+            lots=args.lots,
+            fees=fees,
+            session_filter=session_filter,
+            tfs=tfs,
+            date_from=args.date_from,
+            date_to=args.date_to,
+            out_dir=args.out,
+            print_bars_tf=print_bars_tf,
+        )
+    else:
+        tfs = _parse_tick_tfs(args.tf or DEFAULT_TICK_TFS)
+        results = run_from_ticks(
+            args.db,
+            lots=args.lots,
+            fees=fees,
+            session_filter=session_filter,
+            tfs=tfs,
+            drop_last=not args.keep_last,
+            out_dir=args.out,
+            print_bars_tf=print_bars_tf,
+        )
+
+    print_wick_summary(
+        results,
+        title=f"S16 HHHL ∧ wick  lots={args.lots:g}  fees={fees}",
+    )
+    print_by_day(results)
+    write_outputs(results, args.out)
+    print(f"wrote {args.out}", flush=True)
+    print("Not paper. Not live. Pick a TF row first.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/goldpetal/backtest_s16_hhhl_wick.py
+++ b/goldpetal/backtest_s16_hhhl_wick.py
@@ -23,7 +23,6 @@ from backtest_hhhl_candles import (
     Candle,
     TfResult,
     make_charge_cfg,
-    print_by_day,
     write_outputs,
 )
 from backtest_wick_candles import (
@@ -119,6 +118,134 @@ def _gap_tag(gap: float) -> str:
 
 def _gaps_eq(a: float, b: float) -> bool:
     return abs(float(a) - float(b)) < 1e-9
+
+
+def _split_tf_tag(name: str) -> tuple[str, str]:
+    tf, sep, tag = name.partition(":")
+    return tf, tag if sep else "g?"
+
+
+def _group_gap_results(
+    results: list[TfResult],
+) -> tuple[list[str], list[str], dict[str, dict[str, TfResult]]]:
+    tf_order: list[str] = []
+    tag_order: list[str] = []
+    by: dict[str, dict[str, TfResult]] = {}
+    for r in results:
+        tf, tag = _split_tf_tag(r.tf)
+        if tf not in by:
+            by[tf] = {}
+            tf_order.append(tf)
+        by[tf][tag] = r
+        if tag not in tag_order:
+            tag_order.append(tag)
+    return tf_order, tag_order, by
+
+
+def print_gap_compare(results: list[TfResult]) -> None:
+    """One block per TF: every wick gap, plus Δ₹ vs the first gap (g0)."""
+    tf_order, tag_order, by = _group_gap_results(results)
+    if not tf_order:
+        return
+    base = tag_order[0]
+    print(f"=== Wick-gap compare — all TF × all gaps (Δ₹ vs {base}) ===")
+    for tf in tf_order:
+        row = by[tf]
+        any_r = next(iter(row.values()))
+        print(f"  {tf}  bars={any_r.n_bars}")
+        print(
+            f"    {'gap':>4}  {'tr':>4}  {'L/S':>7}  {'win%':>6}  "
+            f"{'₹':>10}  {'fees':>8}  {'maxDD':>8}  {'Δ₹':>10}"
+        )
+        base_pnl = row[base].after_tax_pnl_inr if base in row else 0.0
+        for tag in tag_order:
+            r = row.get(tag)
+            if r is None:
+                print(f"    {tag:>4}  —")
+                continue
+            delta = "—" if tag == base else f"{r.after_tax_pnl_inr - base_pnl:+.0f}"
+            print(
+                f"    {tag:>4}  {r.n_trades:4d}  {r.n_long:3d}/{r.n_short:<3d}  "
+                f"{100 * r.win_rate:5.1f}%  {r.after_tax_pnl_inr:10.0f}  "
+                f"{r.fees_inr:8.0f}  {r.max_dd_inr:8.0f}  {delta:>10}"
+            )
+        print()
+    print(f"Δ₹ = this gap minus {base}. Positive means the wider wick gap helped after tax.")
+    print()
+
+
+def print_by_day_gaps(results: list[TfResult]) -> None:
+    tf_order, tag_order, by = _group_gap_results(results)
+    print("=== Day-by-day after-tax ₹ — all TF × all gaps ===")
+    for tf in tf_order:
+        days: set[str] = set()
+        for r in by[tf].values():
+            days.update(r.by_day)
+        if not days:
+            continue
+        print(f"  -- {tf} --")
+        for day in sorted(days):
+            bits: list[str] = []
+            for tag in tag_order:
+                r = by[tf].get(tag)
+                d = r.by_day.get(day) if r else None
+                if not d:
+                    bits.append(f"{tag}:—")
+                    continue
+                bits.append(
+                    f"{tag}:{d['after_tax_pnl_inr']:+.0f}({int(d['n_trades'])}t)"
+                )
+            print(f"  {day}  " + "  ".join(bits))
+    print()
+
+
+def write_gap_compare_csv(path: Path, results: list[TfResult]) -> None:
+    tf_order, tag_order, by = _group_gap_results(results)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "tf",
+        "gap",
+        "n_bars",
+        "n_trades",
+        "n_long",
+        "n_short",
+        "win_rate",
+        "gross_pts",
+        "fees_inr",
+        "after_tax_pnl_inr",
+        "max_dd_inr",
+        "delta_vs_base_inr",
+    ]
+    base = tag_order[0] if tag_order else ""
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        for tf in tf_order:
+            base_pnl = (
+                by[tf][base].after_tax_pnl_inr if base in by[tf] else 0.0
+            )
+            for tag in tag_order:
+                r = by[tf].get(tag)
+                if r is None:
+                    continue
+                w.writerow(
+                    {
+                        "tf": tf,
+                        "gap": tag,
+                        "n_bars": r.n_bars,
+                        "n_trades": r.n_trades,
+                        "n_long": r.n_long,
+                        "n_short": r.n_short,
+                        "win_rate": round(r.win_rate, 4),
+                        "gross_pts": round(r.gross_pts, 2),
+                        "fees_inr": round(r.fees_inr, 2),
+                        "after_tax_pnl_inr": round(r.after_tax_pnl_inr, 2),
+                        "max_dd_inr": round(r.max_dd_inr, 2),
+                        "delta_vs_base_inr": round(
+                            r.after_tax_pnl_inr - base_pnl, 2
+                        ),
+                    }
+                )
 
 
 def run_from_ticks(
@@ -353,10 +480,11 @@ def main() -> None:
             f"S16 C>prev HH/LL / C<prev wick-gap  lots={args.lots:g}  fees={fees}"
         ),
     )
-    day_rows = [r for r in results if r.tf.endswith(":" + _gap_tag(print_gap))]
-    print_by_day(day_rows or results)
+    print_gap_compare(results)
+    print_by_day_gaps(results)
     write_outputs(results, args.out)
-    print(f"wrote {args.out}", flush=True)
+    write_gap_compare_csv(args.out / "gap_compare.csv", results)
+    print(f"wrote {args.out} (including gap_compare.csv)", flush=True)
     print("Not paper. Not live. Pick a TF row first.", flush=True)
 
 

--- a/goldpetal/backtest_s16_hhhl_wick.py
+++ b/goldpetal/backtest_s16_hhhl_wick.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Backtest the one S16 formula: HH/LL AND wick, same-candle FLIP.
+"""Backtest the one S16 formula: up-close HH/LL, down-close wick, FLIP.
 
 Research only. Do not paper or live-enable until a 100-lot + fees row is picked.
 
@@ -59,10 +59,12 @@ def write_walk_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         "high",
         "low",
         "close",
+        "prev_close",
         "prev_high",
         "prev_low",
         "upper",
         "lower",
+        "gate",
         "hhhl",
         "wick",
         "rule",
@@ -103,6 +105,7 @@ def run_from_ticks(
     drop_last: bool,
     out_dir: Path,
     print_bars_tf: str | None,
+    print_skips: bool,
 ) -> list[TfResult]:
     rows = load_ltp_rows(db)
     if not rows:
@@ -126,15 +129,22 @@ def run_from_ticks(
         walk = walk_candles(candles)
         write_walk_csv(out_dir / f"{name}_walk.csv", walk)
         if print_bars_tf == name:
+            shown = walk if print_skips else [row for row in walk if row["action"] != "skip"]
             print(flush=True)
-            print(f"=== {name} bars (finished) ===", flush=True)
-            for row in walk:
+            print(
+                f"=== {name} bars (finished"
+                + ("" if print_skips else ", skips hidden")
+                + ") ===",
+                flush=True,
+            )
+            for row in shown:
                 print(
                     f"{row['time']:<22} O={row['open']:.1f} H={row['high']:.1f} "
                     f"L={row['low']:.1f} C={row['close']:.1f}  "
+                    f"gate={row['gate']:<4}  "
                     f"U={row['upper']:.1f} Lw={row['lower']:.1f}  "
                     f"hhhl={row['hhhl']:<5} wick={row['wick']:<5}  "
-                    f"{row['rule']:<32} → {str(row['side']).upper():<5}  "
+                    f"{row['rule']:<28} → {str(row['side']).upper():<5}  "
                     f"{row['action']:<5}  {row['pos_before']}→{row['pos_after']}",
                     flush=True,
                 )
@@ -151,6 +161,7 @@ def run_from_angel(
     date_to: str,
     out_dir: Path,
     print_bars_tf: str | None,
+    print_skips: bool,
 ) -> list[TfResult]:
     from explain_s14_candles import (
         ANGEL_INTERVAL,
@@ -207,11 +218,12 @@ def run_from_angel(
         walk = walk_candles(candles)
         write_walk_csv(out_dir / f"{tf}_{symbol}.csv", walk)
         if print_bars_tf == tf:
+            shown = walk if print_skips else [row for row in walk if row["action"] != "skip"]
             print(flush=True)
             print(f"=== {tf} {symbol} ===", flush=True)
-            for row in walk:
+            for row in shown:
                 print(
-                    f"{row['time']:<22} {row['rule']:<32} → "
+                    f"{row['time']:<22} gate={row['gate']:<4} {row['rule']:<28} → "
                     f"{str(row['side']).upper():<5} {row['action']}",
                     flush=True,
                 )
@@ -232,6 +244,7 @@ def main() -> None:
     ap.add_argument("--no-session", action="store_true")
     ap.add_argument("--keep-last", action="store_true", help="keep still-forming last tick bar")
     ap.add_argument("--print-bars", default="30m", help="print this TF's bars (or '')")
+    ap.add_argument("--print-skips", action="store_true", help="include skip rows in the bar dump")
     ap.add_argument("--out", type=Path, default=Path("data/backtests/s16_hhhl_wick"))
     args = ap.parse_args()
     fees = bool(args.fees) and not bool(args.no_fees)
@@ -260,6 +273,7 @@ def main() -> None:
             date_to=args.date_to,
             out_dir=args.out,
             print_bars_tf=print_bars_tf,
+            print_skips=bool(args.print_skips),
         )
     else:
         tfs = _parse_tick_tfs(args.tf or DEFAULT_TICK_TFS)
@@ -272,11 +286,12 @@ def main() -> None:
             drop_last=not args.keep_last,
             out_dir=args.out,
             print_bars_tf=print_bars_tf,
+            print_skips=bool(args.print_skips),
         )
 
     print_wick_summary(
         results,
-        title=f"S16 HHHL ∧ wick  lots={args.lots:g}  fees={fees}",
+        title=f"S16 C>prev HH/LL / C<prev wick  lots={args.lots:g}  fees={fees}",
     )
     print_by_day(results)
     write_outputs(results, args.out)

--- a/goldpetal/backtest_s16_hhhl_wick.py
+++ b/goldpetal/backtest_s16_hhhl_wick.py
@@ -5,6 +5,8 @@ Research only. Do not paper or live-enable until a 100-lot + fees row is picked.
 
   python3 backtest_s16_hhhl_wick.py --db data/ticks.db --lots 100 --session --fees
   ./venv/bin/python backtest_s16_hhhl_wick.py --from-angel --tf 30m,1h,1d --from 2026-08-02
+
+Default sweeps wick gaps 0,3,5,10 on the down-close path. 30m bars print for gap=3.
 """
 
 from __future__ import annotations
@@ -64,6 +66,8 @@ def write_walk_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         "prev_low",
         "upper",
         "lower",
+        "wick_gap",
+        "min_wick_gap",
         "gate",
         "hhhl",
         "wick",
@@ -95,6 +99,28 @@ def _parse_tick_tfs(raw: str) -> list[tuple[str, int]]:
     return out
 
 
+def _parse_gaps(raw: str) -> list[float]:
+    out: list[float] = []
+    for bit in (x.strip() for x in raw.split(",") if x.strip()):
+        g = float(bit)
+        if g < 0:
+            raise SystemExit(f"wick gap must be ≥ 0, got {g}")
+        out.append(g)
+    if not out:
+        raise SystemExit("no wick gaps")
+    return out
+
+
+def _gap_tag(gap: float) -> str:
+    if float(gap) == int(gap):
+        return f"g{int(gap)}"
+    return f"g{gap:g}"
+
+
+def _gaps_eq(a: float, b: float) -> bool:
+    return abs(float(a) - float(b)) < 1e-9
+
+
 def run_from_ticks(
     db: Path,
     *,
@@ -106,6 +132,8 @@ def run_from_ticks(
     out_dir: Path,
     print_bars_tf: str | None,
     print_skips: bool,
+    wick_gaps: list[float],
+    print_gap: float,
 ) -> list[TfResult]:
     rows = load_ltp_rows(db)
     if not rows:
@@ -117,37 +145,40 @@ def run_from_ticks(
         if drop_last and len(candles) >= 2:
             candles = candles[:-1]
         use_session = session_filter and name != "1d"
-        r = simulate_s16(
-            candles,
-            tf=f"{name}:s16",
-            lots=lots,
-            fees=fees,
-            session_filter=use_session,
-            charge_cfg=cfg,
-        )
-        results.append(r)
-        walk = walk_candles(candles)
-        write_walk_csv(out_dir / f"{name}_walk.csv", walk)
-        if print_bars_tf == name:
-            shown = walk if print_skips else [row for row in walk if row["action"] != "skip"]
-            print(flush=True)
-            print(
-                f"=== {name} bars (finished"
-                + ("" if print_skips else ", skips hidden")
-                + ") ===",
-                flush=True,
+        for gap in wick_gaps:
+            tag = _gap_tag(gap)
+            r = simulate_s16(
+                candles,
+                tf=f"{name}:{tag}",
+                lots=lots,
+                fees=fees,
+                session_filter=use_session,
+                charge_cfg=cfg,
+                min_wick_gap=gap,
             )
-            for row in shown:
+            results.append(r)
+            walk = walk_candles(candles, min_wick_gap=gap)
+            write_walk_csv(out_dir / f"{name}_{tag}_walk.csv", walk)
+            if print_bars_tf == name and _gaps_eq(gap, print_gap):
+                shown = walk if print_skips else [row for row in walk if row["action"] != "skip"]
+                print(flush=True)
                 print(
-                    f"{row['time']:<22} O={row['open']:.1f} H={row['high']:.1f} "
-                    f"L={row['low']:.1f} C={row['close']:.1f}  "
-                    f"gate={row['gate']:<4}  "
-                    f"U={row['upper']:.1f} Lw={row['lower']:.1f}  "
-                    f"hhhl={row['hhhl']:<5} wick={row['wick']:<5}  "
-                    f"{row['rule']:<28} → {str(row['side']).upper():<5}  "
-                    f"{row['action']:<5}  {row['pos_before']}→{row['pos_after']}",
+                    f"=== {name} bars wick-gap={gap:g} (finished"
+                    + ("" if print_skips else ", skips hidden")
+                    + ") ===",
                     flush=True,
                 )
+                for row in shown:
+                    print(
+                        f"{row['time']:<22} O={row['open']:.1f} H={row['high']:.1f} "
+                        f"L={row['low']:.1f} C={row['close']:.1f}  "
+                        f"gate={row['gate']:<4}  "
+                        f"U={row['upper']:.1f} Lw={row['lower']:.1f}  "
+                        f"Δ={row['wick_gap']:.1f}  "
+                        f"{row['rule']:<32} → {str(row['side']).upper():<5}  "
+                        f"{row['action']:<5}  {row['pos_before']}→{row['pos_after']}",
+                        flush=True,
+                    )
     return results
 
 
@@ -162,6 +193,8 @@ def run_from_angel(
     out_dir: Path,
     print_bars_tf: str | None,
     print_skips: bool,
+    wick_gaps: list[float],
+    print_gap: float,
 ) -> list[TfResult]:
     from explain_s14_candles import (
         ANGEL_INTERVAL,
@@ -206,27 +239,31 @@ def run_from_angel(
             raw = [b for b in raw if in_session_dt(parse_bar_ts(b["time"]), tf=tf)]
         raw = [b for b in raw if bar_is_finished(b["time"], tf, now)]
         candles = candles_from_dicts(raw)
-        r = simulate_s16(
-            candles,
-            tf=f"{tf}:s16",
-            lots=lots,
-            fees=fees,
-            session_filter=False,
-            charge_cfg=cfg,
-        )
-        results.append(r)
-        walk = walk_candles(candles)
-        write_walk_csv(out_dir / f"{tf}_{symbol}.csv", walk)
-        if print_bars_tf == tf:
-            shown = walk if print_skips else [row for row in walk if row["action"] != "skip"]
-            print(flush=True)
-            print(f"=== {tf} {symbol} ===", flush=True)
-            for row in shown:
-                print(
-                    f"{row['time']:<22} gate={row['gate']:<4} {row['rule']:<28} → "
-                    f"{str(row['side']).upper():<5} {row['action']}",
-                    flush=True,
-                )
+        for gap in wick_gaps:
+            tag = _gap_tag(gap)
+            r = simulate_s16(
+                candles,
+                tf=f"{tf}:{tag}",
+                lots=lots,
+                fees=fees,
+                session_filter=False,
+                charge_cfg=cfg,
+                min_wick_gap=gap,
+            )
+            results.append(r)
+            walk = walk_candles(candles, min_wick_gap=gap)
+            write_walk_csv(out_dir / f"{tf}_{tag}_{symbol}.csv", walk)
+            if print_bars_tf == tf and _gaps_eq(gap, print_gap):
+                shown = walk if print_skips else [row for row in walk if row["action"] != "skip"]
+                print(flush=True)
+                print(f"=== {tf} {symbol} wick-gap={gap:g} ===", flush=True)
+                for row in shown:
+                    print(
+                        f"{row['time']:<22} gate={row['gate']:<4} Δ={row['wick_gap']:.1f} "
+                        f"{row['rule']:<32} → "
+                        f"{str(row['side']).upper():<5} {row['action']}",
+                        flush=True,
+                    )
     return results
 
 
@@ -245,6 +282,17 @@ def main() -> None:
     ap.add_argument("--keep-last", action="store_true", help="keep still-forming last tick bar")
     ap.add_argument("--print-bars", default="30m", help="print this TF's bars (or '')")
     ap.add_argument("--print-skips", action="store_true", help="include skip rows in the bar dump")
+    ap.add_argument(
+        "--wick-gaps",
+        default="0,3,5,10",
+        help="comma list of min |upper-lower| on down-close wicks",
+    )
+    ap.add_argument(
+        "--print-gap",
+        type=float,
+        default=3.0,
+        help="which wick gap gets the 30m bar dump",
+    )
     ap.add_argument("--out", type=Path, default=Path("data/backtests/s16_hhhl_wick"))
     args = ap.parse_args()
     fees = bool(args.fees) and not bool(args.no_fees)
@@ -253,9 +301,15 @@ def main() -> None:
     if print_bars_tf == "30":
         print_bars_tf = "30m"
 
+    wick_gaps = _parse_gaps(args.wick_gaps)
+    print_gap = float(args.print_gap)
+    if not any(_gaps_eq(print_gap, g) for g in wick_gaps):
+        print_gap = wick_gaps[0]
+
     print(FORMULA, flush=True)
     print(
         f"lots={args.lots:g}  fees={fees}  session={session_filter}  "
+        f"wick_gaps={','.join(str(g) if g != int(g) else str(int(g)) for g in wick_gaps)}  "
         f"source={'Angel' if args.from_angel else args.db}",
         flush=True,
     )
@@ -274,6 +328,8 @@ def main() -> None:
             out_dir=args.out,
             print_bars_tf=print_bars_tf,
             print_skips=bool(args.print_skips),
+            wick_gaps=wick_gaps,
+            print_gap=print_gap,
         )
     else:
         tfs = _parse_tick_tfs(args.tf or DEFAULT_TICK_TFS)
@@ -287,13 +343,18 @@ def main() -> None:
             out_dir=args.out,
             print_bars_tf=print_bars_tf,
             print_skips=bool(args.print_skips),
+            wick_gaps=wick_gaps,
+            print_gap=print_gap,
         )
 
     print_wick_summary(
         results,
-        title=f"S16 C>prev HH/LL / C<prev wick  lots={args.lots:g}  fees={fees}",
+        title=(
+            f"S16 C>prev HH/LL / C<prev wick-gap  lots={args.lots:g}  fees={fees}"
+        ),
     )
-    print_by_day(results)
+    day_rows = [r for r in results if r.tf.endswith(":" + _gap_tag(print_gap))]
+    print_by_day(day_rows or results)
     write_outputs(results, args.out)
     print(f"wrote {args.out}", flush=True)
     print("Not paper. Not live. Pick a TF row first.", flush=True)

--- a/goldpetal/s16_hhhl_wick.py
+++ b/goldpetal/s16_hhhl_wick.py
@@ -1,0 +1,227 @@
+"""S16 research formula: HH/LL structure AND wick on the same finished candle.
+
+Not paper. Not live. Backtest first.
+
+Wait for the candle to **finish**. On that closed bar vs the previous closed bar:
+
+  Structure (S12):
+    LONG  = higher high AND green  (H > prevH and C > O)
+    SHORT = lower low  AND red    (L < prevL and C < O)
+
+  Wick (S14 raw, nothing else):
+    upper = high − max(open, close)
+    lower = min(open, close) − low
+    LONG  = lower > upper
+    SHORT = upper > lower
+    equal = skip
+
+  Combined AND:
+    LONG  only if structure LONG  and wick LONG
+    SHORT only if structure SHORT and wick SHORT
+    else skip
+
+FLIP if already the other side. Fill at this bar's close.
+Stay in until the opposite AND signal (or session flatten / last bar).
+No range skip. No bald-body. No open=high/low (that is S14).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backtest_hhhl_candles import Candle, Trade, in_session, make_charge_cfg
+from backtest_wick_candles import _tf_result_from_trades
+from charges import ChargeConfig, apply_charges_and_tax
+from wick_candles import wick_measure
+
+FORMULA = (
+    "Wait for the candle to finish. Same closed bar vs previous closed bar: "
+    "HH+green AND lower wick > upper wick → LONG | "
+    "LL+red AND upper wick > lower wick → SHORT | "
+    "else skip. FLIP if already the other side. Fill at this bar's close."
+)
+
+
+def hhhl_side(prev: Candle, cur: Candle) -> str | None:
+    want_long = cur.high > prev.high and cur.close > cur.open
+    want_short = cur.low < prev.low and cur.close < cur.open
+    if want_long and not want_short:
+        return "long"
+    if want_short and not want_long:
+        return "short"
+    return None
+
+
+def wick_raw_side(cur: Candle) -> str | None:
+    return wick_measure(cur.open, cur.high, cur.low, cur.close).dominant
+
+
+def s16_bar_decision(prev: Candle, cur: Candle) -> tuple[str | None, str]:
+    """One finished candle → ('long'|'short'|None, why)."""
+    hh = hhhl_side(prev, cur)
+    wk = wick_raw_side(cur)
+    if hh == "long" and wk == "long":
+        return "long", "HH+green AND lower wick"
+    if hh == "short" and wk == "short":
+        return "short", "LL+red AND upper wick"
+    hh_s = hh or "none"
+    wk_s = wk or "none"
+    return None, f"skip (hhhl={hh_s} wick={wk_s})"
+
+
+def explain_bar(prev: Candle, cur: Candle, pos: str) -> dict[str, Any]:
+    m = wick_measure(cur.open, cur.high, cur.low, cur.close)
+    hh = hhhl_side(prev, cur)
+    wk = wick_raw_side(cur)
+    side, why = s16_bar_decision(prev, cur)
+    prev_pos = pos
+    action = "skip"
+    pos_after = pos
+    if side is None:
+        action = "skip"
+    elif side == pos:
+        action = "hold"
+    else:
+        action = "FLIP" if pos != "flat" else "enter"
+        pos_after = side
+    return {
+        "time": cur.time,
+        "open": cur.open,
+        "high": cur.high,
+        "low": cur.low,
+        "close": cur.close,
+        "prev_high": prev.high,
+        "prev_low": prev.low,
+        "upper": round(m.upper, 2),
+        "lower": round(m.lower, 2),
+        "hhhl": hh or "none",
+        "wick": wk or "none",
+        "rule": why,
+        "side": side or "skip",
+        "action": action,
+        "pos_before": prev_pos,
+        "pos_after": pos_after,
+    }
+
+
+def walk_candles(candles: list[Candle]) -> list[dict[str, Any]]:
+    pos = "flat"
+    out: list[dict[str, Any]] = []
+    for i in range(1, len(candles)):
+        row = explain_bar(candles[i - 1], candles[i], pos)
+        pos = str(row["pos_after"])
+        out.append(row)
+    return out
+
+
+def _close_leg(
+    *,
+    tf: str,
+    side: str,
+    entry_time: str,
+    entry_px: float,
+    exit_c: Candle,
+    cfg: ChargeConfig,
+) -> Trade:
+    if side == "LONG":
+        pts = exit_c.close - entry_px
+        order_side = "BUY"
+    else:
+        pts = entry_px - exit_c.close
+        order_side = "SELL"
+    settled = apply_charges_and_tax(
+        pts,
+        cfg,
+        side=order_side,
+        entry_price=entry_px,
+        exit_price=exit_c.close,
+    )
+    return Trade(
+        tf=tf,
+        side=side,
+        entry_time=entry_time,
+        entry_px=entry_px,
+        exit_time=exit_c.time,
+        exit_px=exit_c.close,
+        gross_pts=float(pts) * float(cfg.lot_size),
+        gross_pnl_inr=float(settled["gross_pnl"]),
+        after_tax_pnl_inr=float(settled["pnl_after_tax"]),
+        fees_inr=float(settled["charges"]),
+        lots=float(cfg.lot_size),
+    )
+
+
+def simulate_s16(
+    candles: list[Candle],
+    *,
+    tf: str,
+    lots: float = 100.0,
+    fees: bool = True,
+    session_filter: bool = True,
+    market_open: str = "09:00",
+    market_close: str = "23:30",
+    charge_cfg: ChargeConfig | None = None,
+) -> Any:
+    """AND formula with same-candle FLIP. Fill at signal-bar close."""
+    cfg = charge_cfg or make_charge_cfg(fees=fees, lots=lots)
+    trades: list[Trade] = []
+    side: str | None = None
+    entry_px = 0.0
+    entry_time = ""
+
+    def close_trade(exit_c: Candle) -> None:
+        nonlocal side, entry_px, entry_time
+        assert side is not None
+        trades.append(
+            _close_leg(
+                tf=tf,
+                side=side,
+                entry_time=entry_time,
+                entry_px=entry_px,
+                exit_c=exit_c,
+                cfg=cfg,
+            )
+        )
+        side = None
+
+    for i in range(1, len(candles)):
+        prev, cur = candles[i - 1], candles[i]
+        sess_ok = (not session_filter) or in_session(
+            cur, open_hhmm=market_open, close_hhmm=market_close
+        )
+        if side is not None and session_filter and not sess_ok:
+            close_trade(cur)
+            continue
+        if session_filter and not sess_ok:
+            continue
+
+        want, _why = s16_bar_decision(prev, cur)
+        want_long = want == "long"
+        want_short = want == "short"
+
+        if side == "LONG":
+            if want_short:
+                close_trade(cur)
+                side = "SHORT"
+                entry_px = cur.close
+                entry_time = cur.time
+            continue
+        if side == "SHORT":
+            if want_long:
+                close_trade(cur)
+                side = "LONG"
+                entry_px = cur.close
+                entry_time = cur.time
+            continue
+        if want_long:
+            side = "LONG"
+            entry_px = cur.close
+            entry_time = cur.time
+        elif want_short:
+            side = "SHORT"
+            entry_px = cur.close
+            entry_time = cur.time
+
+    if side is not None and candles:
+        close_trade(candles[-1])
+    return _tf_result_from_trades(tf, len(candles), trades)

--- a/goldpetal/s16_hhhl_wick.py
+++ b/goldpetal/s16_hhhl_wick.py
@@ -12,9 +12,10 @@ Wait for the candle to **finish**. Same closed bar vs previous closed bar:
   If close < previous close → wick only (S14 raw):
     upper = high − max(open, close)
     lower = min(open, close) − low
+    require |upper − lower| ≥ min_wick_gap (default 3; experiment 0/3/5/10)
     LONG  = lower > upper
     SHORT = upper > lower
-    equal = skip (HH/LL is ignored on a down close)
+    else skip (HH/LL is ignored on a down close)
 
   If close = previous close → skip
 
@@ -35,7 +36,7 @@ from wick_candles import wick_measure
 FORMULA = (
     "Wait for the candle to finish. Same closed bar vs previous close: "
     "C>prevC → HH/LL (HH+green LONG, LL+red SHORT) | "
-    "C<prevC → wick (lower>upper LONG, upper>lower SHORT) | "
+    "C<prevC → wick if |U−L| ≥ gap (lower>upper LONG, upper>lower SHORT) | "
     "C=prevC skip. FLIP if already the other side. Fill at this bar's close."
 )
 
@@ -54,7 +55,12 @@ def wick_raw_side(cur: Candle) -> str | None:
     return wick_measure(cur.open, cur.high, cur.low, cur.close).dominant
 
 
-def s16_bar_decision(prev: Candle, cur: Candle) -> tuple[str | None, str]:
+def s16_bar_decision(
+    prev: Candle,
+    cur: Candle,
+    *,
+    min_wick_gap: float = 3.0,
+) -> tuple[str | None, str]:
     """One finished candle → ('long'|'short'|None, why)."""
     if cur.close > prev.close:
         hh = hhhl_side(prev, cur)
@@ -64,20 +70,29 @@ def s16_bar_decision(prev: Candle, cur: Candle) -> tuple[str | None, str]:
             return "short", "C>prev → LL+red"
         return None, "C>prev → no HH/LL"
     if cur.close < prev.close:
-        wk = wick_raw_side(cur)
-        if wk == "long":
+        m = wick_measure(cur.open, cur.high, cur.low, cur.close)
+        diff = abs(m.upper - m.lower)
+        if diff < float(min_wick_gap):
+            return None, f"C<prev → wick gap {diff:.1f}<{float(min_wick_gap):g}"
+        if m.lower > m.upper:
             return "long", "C<prev → lower wick"
-        if wk == "short":
+        if m.upper > m.lower:
             return "short", "C<prev → upper wick"
         return None, "C<prev → equal wick"
     return None, "C=prev skip"
 
 
-def explain_bar(prev: Candle, cur: Candle, pos: str) -> dict[str, Any]:
+def explain_bar(
+    prev: Candle,
+    cur: Candle,
+    pos: str,
+    *,
+    min_wick_gap: float = 3.0,
+) -> dict[str, Any]:
     m = wick_measure(cur.open, cur.high, cur.low, cur.close)
     hh = hhhl_side(prev, cur)
     wk = wick_raw_side(cur)
-    side, why = s16_bar_decision(prev, cur)
+    side, why = s16_bar_decision(prev, cur, min_wick_gap=min_wick_gap)
     if cur.close > prev.close:
         gate = "hhhl"
     elif cur.close < prev.close:
@@ -105,6 +120,8 @@ def explain_bar(prev: Candle, cur: Candle, pos: str) -> dict[str, Any]:
         "prev_low": prev.low,
         "upper": round(m.upper, 2),
         "lower": round(m.lower, 2),
+        "wick_gap": round(abs(m.upper - m.lower), 2),
+        "min_wick_gap": float(min_wick_gap),
         "gate": gate,
         "hhhl": hh or "none",
         "wick": wk or "none",
@@ -116,11 +133,15 @@ def explain_bar(prev: Candle, cur: Candle, pos: str) -> dict[str, Any]:
     }
 
 
-def walk_candles(candles: list[Candle]) -> list[dict[str, Any]]:
+def walk_candles(
+    candles: list[Candle],
+    *,
+    min_wick_gap: float = 3.0,
+) -> list[dict[str, Any]]:
     pos = "flat"
     out: list[dict[str, Any]] = []
     for i in range(1, len(candles)):
-        row = explain_bar(candles[i - 1], candles[i], pos)
+        row = explain_bar(candles[i - 1], candles[i], pos, min_wick_gap=min_wick_gap)
         pos = str(row["pos_after"])
         out.append(row)
     return out
@@ -173,6 +194,7 @@ def simulate_s16(
     market_open: str = "09:00",
     market_close: str = "23:30",
     charge_cfg: ChargeConfig | None = None,
+    min_wick_gap: float = 3.0,
 ) -> Any:
     """Close-vs-prev gate with same-candle FLIP. Fill at signal-bar close."""
     cfg = charge_cfg or make_charge_cfg(fees=fees, lots=lots)
@@ -207,7 +229,7 @@ def simulate_s16(
         if session_filter and not sess_ok:
             continue
 
-        want, _why = s16_bar_decision(prev, cur)
+        want, _why = s16_bar_decision(prev, cur, min_wick_gap=min_wick_gap)
         want_long = want == "long"
         want_short = want == "short"
 

--- a/goldpetal/s16_hhhl_wick.py
+++ b/goldpetal/s16_hhhl_wick.py
@@ -1,27 +1,25 @@
-"""S16 research formula: HH/LL structure AND wick on the same finished candle.
+"""S16 research formula: close vs previous close picks HH/LL or wick.
 
 Not paper. Not live. Backtest first.
 
-Wait for the candle to **finish**. On that closed bar vs the previous closed bar:
+Wait for the candle to **finish**. Same closed bar vs previous closed bar:
 
-  Structure (S12):
+  If close > previous close → HH/LL only (S12):
     LONG  = higher high AND green  (H > prevH and C > O)
     SHORT = lower low  AND red    (L < prevL and C < O)
+    else skip (wicks are ignored on an up close)
 
-  Wick (S14 raw, nothing else):
+  If close < previous close → wick only (S14 raw):
     upper = high − max(open, close)
     lower = min(open, close) − low
     LONG  = lower > upper
     SHORT = upper > lower
-    equal = skip
+    equal = skip (HH/LL is ignored on a down close)
 
-  Combined AND:
-    LONG  only if structure LONG  and wick LONG
-    SHORT only if structure SHORT and wick SHORT
-    else skip
+  If close = previous close → skip
 
 FLIP if already the other side. Fill at this bar's close.
-Stay in until the opposite AND signal (or session flatten / last bar).
+Stay in until the opposite signal (or session flatten / last bar).
 No range skip. No bald-body. No open=high/low (that is S14).
 """
 
@@ -35,10 +33,10 @@ from charges import ChargeConfig, apply_charges_and_tax
 from wick_candles import wick_measure
 
 FORMULA = (
-    "Wait for the candle to finish. Same closed bar vs previous closed bar: "
-    "HH+green AND lower wick > upper wick → LONG | "
-    "LL+red AND upper wick > lower wick → SHORT | "
-    "else skip. FLIP if already the other side. Fill at this bar's close."
+    "Wait for the candle to finish. Same closed bar vs previous close: "
+    "C>prevC → HH/LL (HH+green LONG, LL+red SHORT) | "
+    "C<prevC → wick (lower>upper LONG, upper>lower SHORT) | "
+    "C=prevC skip. FLIP if already the other side. Fill at this bar's close."
 )
 
 
@@ -58,15 +56,21 @@ def wick_raw_side(cur: Candle) -> str | None:
 
 def s16_bar_decision(prev: Candle, cur: Candle) -> tuple[str | None, str]:
     """One finished candle → ('long'|'short'|None, why)."""
-    hh = hhhl_side(prev, cur)
-    wk = wick_raw_side(cur)
-    if hh == "long" and wk == "long":
-        return "long", "HH+green AND lower wick"
-    if hh == "short" and wk == "short":
-        return "short", "LL+red AND upper wick"
-    hh_s = hh or "none"
-    wk_s = wk or "none"
-    return None, f"skip (hhhl={hh_s} wick={wk_s})"
+    if cur.close > prev.close:
+        hh = hhhl_side(prev, cur)
+        if hh == "long":
+            return "long", "C>prev → HH+green"
+        if hh == "short":
+            return "short", "C>prev → LL+red"
+        return None, "C>prev → no HH/LL"
+    if cur.close < prev.close:
+        wk = wick_raw_side(cur)
+        if wk == "long":
+            return "long", "C<prev → lower wick"
+        if wk == "short":
+            return "short", "C<prev → upper wick"
+        return None, "C<prev → equal wick"
+    return None, "C=prev skip"
 
 
 def explain_bar(prev: Candle, cur: Candle, pos: str) -> dict[str, Any]:
@@ -74,6 +78,12 @@ def explain_bar(prev: Candle, cur: Candle, pos: str) -> dict[str, Any]:
     hh = hhhl_side(prev, cur)
     wk = wick_raw_side(cur)
     side, why = s16_bar_decision(prev, cur)
+    if cur.close > prev.close:
+        gate = "hhhl"
+    elif cur.close < prev.close:
+        gate = "wick"
+    else:
+        gate = "equal"
     prev_pos = pos
     action = "skip"
     pos_after = pos
@@ -90,10 +100,12 @@ def explain_bar(prev: Candle, cur: Candle, pos: str) -> dict[str, Any]:
         "high": cur.high,
         "low": cur.low,
         "close": cur.close,
+        "prev_close": prev.close,
         "prev_high": prev.high,
         "prev_low": prev.low,
         "upper": round(m.upper, 2),
         "lower": round(m.lower, 2),
+        "gate": gate,
         "hhhl": hh or "none",
         "wick": wk or "none",
         "rule": why,
@@ -162,7 +174,7 @@ def simulate_s16(
     market_close: str = "23:30",
     charge_cfg: ChargeConfig | None = None,
 ) -> Any:
-    """AND formula with same-candle FLIP. Fill at signal-bar close."""
+    """Close-vs-prev gate with same-candle FLIP. Fill at signal-bar close."""
     cfg = charge_cfg or make_charge_cfg(fees=fees, lots=lots)
     trades: list[Trade] = []
     side: str | None = None

--- a/goldpetal/test_s16_hhhl_wick.py
+++ b/goldpetal/test_s16_hhhl_wick.py
@@ -1,0 +1,108 @@
+"""S16 = HH/LL structure AND wick on the same finished candle, then FLIP."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from backtest_hhhl_candles import Candle
+from control_state import ALL_STRATEGY_NAMES
+from s16_hhhl_wick import s16_bar_decision, simulate_s16, walk_candles
+
+
+def _c(t: str, o: float, h: float, l: float, c: float) -> Candle:
+    return Candle(t, o, h, l, c)
+
+
+PREV = _c("2026-08-17 10:00:00", 100.0, 105.0, 99.0, 104.0)
+
+
+def test_formula_skips_hh_green_with_upper_wick() -> None:
+    cur = _c("2026-08-17 10:30:00", 100.0, 120.0, 100.0, 110.0)
+    side, why = s16_bar_decision(PREV, cur)
+    assert side is None
+    assert "wick=short" in why
+
+
+def test_formula_long_on_hh_green_hammer() -> None:
+    cur = _c("2026-08-17 10:30:00", 104.0, 112.0, 90.0, 110.0)
+    side, why = s16_bar_decision(PREV, cur)
+    assert side == "long"
+    assert "HH+green" in why
+
+
+def test_formula_short_on_ll_red_upper_wick() -> None:
+    cur = _c("2026-08-17 10:30:00", 104.0, 130.0, 80.0, 90.0)
+    side, why = s16_bar_decision(PREV, cur)
+    assert side == "short"
+    assert "LL+red" in why
+
+
+def test_equal_wick_skips_even_if_hh_green() -> None:
+    cur = _c("2026-08-17 10:30:00", 104.0, 115.0, 99.0, 110.0)
+    side, why = s16_bar_decision(PREV, cur)
+    assert side is None
+    assert "wick=none" in why
+
+
+def test_enter_then_flip_on_opposite_and() -> None:
+    candles = [
+        PREV,
+        _c("2026-08-17 10:30:00", 104.0, 112.0, 90.0, 110.0),  # AND long @ 110
+        _c("2026-08-17 11:00:00", 110.0, 140.0, 70.0, 80.0),  # LL+red + upper wick → FLIP short @ 80
+        _c("2026-08-17 11:30:00", 80.0, 81.0, 79.0, 80.5),  # skip — leftover flat at last close
+    ]
+    r = simulate_s16(candles, tf="toy:s16", lots=1, fees=False, session_filter=False)
+    assert r.n_trades == 2
+    assert r.trades[0].side == "LONG"
+    assert r.trades[0].entry_px == 110.0
+    assert r.trades[0].exit_px == 80.0
+    assert r.trades[1].side == "SHORT"
+    assert r.trades[1].entry_px == 80.0
+    assert r.trades[1].exit_px == 80.5
+
+
+def test_skip_bar_holds_open_trade() -> None:
+    candles = [
+        PREV,
+        _c("2026-08-17 10:30:00", 104.0, 112.0, 90.0, 110.0),  # long
+        _c("2026-08-17 11:00:00", 110.0, 111.0, 109.0, 110.5),  # no HH/LL, tiny wicks
+        _c("2026-08-17 11:30:00", 110.5, 150.0, 80.0, 90.0),  # LL+red + upper → FLIP
+    ]
+    r = simulate_s16(candles, tf="toy:s16", lots=1, fees=False, session_filter=False)
+    assert r.trades[0].side == "LONG"
+    assert r.trades[0].entry_time == "2026-08-17 10:30:00"
+    assert r.trades[0].exit_time == "2026-08-17 11:30:00"
+
+
+def test_walk_marks_flip() -> None:
+    candles = [
+        PREV,
+        _c("2026-08-17 10:30:00", 104.0, 112.0, 90.0, 110.0),
+        _c("2026-08-17 11:00:00", 110.0, 140.0, 70.0, 80.0),
+    ]
+    rows = walk_candles(candles)
+    assert rows[0]["action"] == "enter"
+    assert rows[0]["pos_after"] == "long"
+    assert rows[1]["action"] == "FLIP"
+    assert rows[1]["pos_after"] == "short"
+
+
+def test_not_wired_to_paper_or_station() -> None:
+    assert "S16_HHHL_WICK" not in ALL_STRATEGY_NAMES
+    station = (Path(__file__).resolve().parent / "station.html").read_text(encoding="utf-8")
+    assert "S16_HHHL_WICK" not in station
+    runner = (Path(__file__).resolve().parent / "run_strategy.py").read_text(encoding="utf-8")
+    assert "s16_hhhl_wick" not in runner
+    assert "ENABLE_S16" not in runner
+
+
+if __name__ == "__main__":
+    test_formula_skips_hh_green_with_upper_wick()
+    test_formula_long_on_hh_green_hammer()
+    test_formula_short_on_ll_red_upper_wick()
+    test_equal_wick_skips_even_if_hh_green()
+    test_enter_then_flip_on_opposite_and()
+    test_skip_bar_holds_open_trade()
+    test_walk_marks_flip()
+    test_not_wired_to_paper_or_station()
+    print("ALL test_s16_hhhl_wick OK")

--- a/goldpetal/test_s16_hhhl_wick.py
+++ b/goldpetal/test_s16_hhhl_wick.py
@@ -1,4 +1,4 @@
-"""S16 = HH/LL structure AND wick on the same finished candle, then FLIP."""
+"""S16: up-close uses HH/LL, down-close uses wick, then FLIP."""
 
 from __future__ import annotations
 
@@ -16,40 +16,54 @@ def _c(t: str, o: float, h: float, l: float, c: float) -> Candle:
 PREV = _c("2026-08-17 10:00:00", 100.0, 105.0, 99.0, 104.0)
 
 
-def test_formula_skips_hh_green_with_upper_wick() -> None:
+def test_up_close_takes_hh_green_even_with_upper_wick() -> None:
+    """C>prev → HH/LL only. Slap wick is ignored."""
     cur = _c("2026-08-17 10:30:00", 100.0, 120.0, 100.0, 110.0)
-    side, why = s16_bar_decision(PREV, cur)
-    assert side is None
-    assert "wick=short" in why
-
-
-def test_formula_long_on_hh_green_hammer() -> None:
-    cur = _c("2026-08-17 10:30:00", 104.0, 112.0, 90.0, 110.0)
+    assert cur.close > PREV.close
     side, why = s16_bar_decision(PREV, cur)
     assert side == "long"
     assert "HH+green" in why
 
 
-def test_formula_short_on_ll_red_upper_wick() -> None:
-    cur = _c("2026-08-17 10:30:00", 104.0, 130.0, 80.0, 90.0)
-    side, why = s16_bar_decision(PREV, cur)
-    assert side == "short"
-    assert "LL+red" in why
-
-
-def test_equal_wick_skips_even_if_hh_green() -> None:
-    cur = _c("2026-08-17 10:30:00", 104.0, 115.0, 99.0, 110.0)
+def test_up_close_without_hhhl_skips_even_if_wick() -> None:
+    cur = _c("2026-08-17 10:30:00", 104.0, 105.0, 90.0, 104.5)
+    assert cur.close > PREV.close
     side, why = s16_bar_decision(PREV, cur)
     assert side is None
-    assert "wick=none" in why
+    assert "no HH/LL" in why
 
 
-def test_enter_then_flip_on_opposite_and() -> None:
+def test_down_close_uses_wick_not_hhhl() -> None:
+    """C<prev → wick. LL+red with a longer lower wick goes LONG."""
+    cur = _c("2026-08-17 10:30:00", 103.0, 104.0, 80.0, 100.0)
+    assert cur.close < PREV.close
+    assert cur.low < PREV.low and cur.close < cur.open
+    side, why = s16_bar_decision(PREV, cur)
+    assert side == "long"
+    assert "lower wick" in why
+
+
+def test_down_close_upper_wick_short() -> None:
+    cur = _c("2026-08-17 10:30:00", 104.0, 130.0, 80.0, 90.0)
+    assert cur.close < PREV.close
+    side, why = s16_bar_decision(PREV, cur)
+    assert side == "short"
+    assert "upper wick" in why
+
+
+def test_equal_close_skips() -> None:
+    cur = _c("2026-08-17 10:30:00", 104.0, 120.0, 90.0, 104.0)
+    side, why = s16_bar_decision(PREV, cur)
+    assert side is None
+    assert "C=prev" in why
+
+
+def test_enter_then_flip() -> None:
     candles = [
         PREV,
-        _c("2026-08-17 10:30:00", 104.0, 112.0, 90.0, 110.0),  # AND long @ 110
-        _c("2026-08-17 11:00:00", 110.0, 140.0, 70.0, 80.0),  # LL+red + upper wick → FLIP short @ 80
-        _c("2026-08-17 11:30:00", 80.0, 81.0, 79.0, 80.5),  # skip — leftover flat at last close
+        _c("2026-08-17 10:30:00", 100.0, 120.0, 100.0, 110.0),  # C>prev HH+green → long @ 110
+        _c("2026-08-17 11:00:00", 110.0, 140.0, 70.0, 80.0),  # C<prev upper wick → FLIP short @ 80
+        _c("2026-08-17 11:30:00", 80.0, 81.0, 79.0, 80.5),
     ]
     r = simulate_s16(candles, tf="toy:s16", lots=1, fees=False, session_filter=False)
     assert r.n_trades == 2
@@ -64,9 +78,9 @@ def test_enter_then_flip_on_opposite_and() -> None:
 def test_skip_bar_holds_open_trade() -> None:
     candles = [
         PREV,
-        _c("2026-08-17 10:30:00", 104.0, 112.0, 90.0, 110.0),  # long
-        _c("2026-08-17 11:00:00", 110.0, 111.0, 109.0, 110.5),  # no HH/LL, tiny wicks
-        _c("2026-08-17 11:30:00", 110.5, 150.0, 80.0, 90.0),  # LL+red + upper → FLIP
+        _c("2026-08-17 10:30:00", 100.0, 120.0, 100.0, 110.0),  # long
+        _c("2026-08-17 11:00:00", 110.0, 111.0, 109.0, 110.5),  # C>prev, no HH/LL
+        _c("2026-08-17 11:30:00", 110.5, 150.0, 80.0, 90.0),  # C<prev upper wick → FLIP
     ]
     r = simulate_s16(candles, tf="toy:s16", lots=1, fees=False, session_filter=False)
     assert r.trades[0].side == "LONG"
@@ -77,14 +91,14 @@ def test_skip_bar_holds_open_trade() -> None:
 def test_walk_marks_flip() -> None:
     candles = [
         PREV,
-        _c("2026-08-17 10:30:00", 104.0, 112.0, 90.0, 110.0),
+        _c("2026-08-17 10:30:00", 100.0, 120.0, 100.0, 110.0),
         _c("2026-08-17 11:00:00", 110.0, 140.0, 70.0, 80.0),
     ]
     rows = walk_candles(candles)
+    assert rows[0]["gate"] == "hhhl"
     assert rows[0]["action"] == "enter"
-    assert rows[0]["pos_after"] == "long"
+    assert rows[1]["gate"] == "wick"
     assert rows[1]["action"] == "FLIP"
-    assert rows[1]["pos_after"] == "short"
 
 
 def test_not_wired_to_paper_or_station() -> None:
@@ -97,11 +111,12 @@ def test_not_wired_to_paper_or_station() -> None:
 
 
 if __name__ == "__main__":
-    test_formula_skips_hh_green_with_upper_wick()
-    test_formula_long_on_hh_green_hammer()
-    test_formula_short_on_ll_red_upper_wick()
-    test_equal_wick_skips_even_if_hh_green()
-    test_enter_then_flip_on_opposite_and()
+    test_up_close_takes_hh_green_even_with_upper_wick()
+    test_up_close_without_hhhl_skips_even_if_wick()
+    test_down_close_uses_wick_not_hhhl()
+    test_down_close_upper_wick_short()
+    test_equal_close_skips()
+    test_enter_then_flip()
     test_skip_bar_holds_open_trade()
     test_walk_marks_flip()
     test_not_wired_to_paper_or_station()

--- a/goldpetal/test_s16_hhhl_wick.py
+++ b/goldpetal/test_s16_hhhl_wick.py
@@ -161,6 +161,37 @@ def test_not_wired_to_paper_or_station() -> None:
     assert "ENABLE_S16" not in runner
 
 
+def test_gap_compare_groups_every_tf_and_gap() -> None:
+    from backtest_s16_hhhl_wick import _group_gap_results, print_gap_compare
+
+    candles = [
+        PREV,
+        _c("2026-08-17 10:30:00", 104.0, 130.0, 80.0, 90.0),
+        _c("2026-08-17 11:00:00", 89.0, 91.0, 85.0, 88.0),
+        _c("2026-08-17 11:30:00", 88.0, 89.0, 87.0, 88.5),
+    ]
+    results = []
+    for tf in ("30m", "1h"):
+        for gap, tag in ((0, "g0"), (3, "g3"), (5, "g5"), (10, "g10")):
+            results.append(
+                simulate_s16(
+                    candles,
+                    tf=f"{tf}:{tag}",
+                    lots=1,
+                    fees=False,
+                    session_filter=False,
+                    min_wick_gap=gap,
+                )
+            )
+    tfs, tags, by = _group_gap_results(results)
+    assert tfs == ["30m", "1h"]
+    assert tags == ["g0", "g3", "g5", "g10"]
+    assert by["30m"]["g0"].n_trades == 2
+    assert by["30m"]["g3"].n_trades == 1
+    assert by["1h"]["g10"].n_trades == 1
+    print_gap_compare(results)
+
+
 if __name__ == "__main__":
     test_up_close_takes_hh_green_even_with_upper_wick()
     test_up_close_without_hhhl_skips_even_if_wick()
@@ -175,4 +206,5 @@ if __name__ == "__main__":
     test_skip_bar_holds_open_trade()
     test_walk_marks_flip()
     test_not_wired_to_paper_or_station()
+    test_gap_compare_groups_every_tf_and_gap()
     print("ALL test_s16_hhhl_wick OK")

--- a/goldpetal/test_s16_hhhl_wick.py
+++ b/goldpetal/test_s16_hhhl_wick.py
@@ -51,11 +51,62 @@ def test_down_close_upper_wick_short() -> None:
     assert "upper wick" in why
 
 
+def test_tiny_wick_gap_skips_when_gap_is_3() -> None:
+    """3 Aug 10:30 style: U=2 Lw=3 must not FLIP when gap=3."""
+    cur = _c("2026-08-17 10:30:00", 104.0, 106.0, 100.0, 103.0)
+    assert cur.close < PREV.close
+    m_long, _why0 = s16_bar_decision(PREV, cur, min_wick_gap=0)
+    m_gap, why3 = s16_bar_decision(PREV, cur, min_wick_gap=3)
+    assert m_long == "long"
+    assert m_gap is None
+    assert "wick gap 1.0<3" in why3
+
+
+def test_clear_wick_still_fires_with_gap_3() -> None:
+    cur = _c("2026-08-17 10:30:00", 104.0, 120.0, 103.0, 103.5)
+    side, why = s16_bar_decision(PREV, cur, min_wick_gap=3)
+    assert side == "short"
+    assert "upper wick" in why
+
+
+def test_up_close_ignores_wick_gap() -> None:
+    cur = _c("2026-08-17 10:30:00", 100.0, 120.0, 100.0, 110.0)
+    side, _ = s16_bar_decision(PREV, cur, min_wick_gap=10)
+    assert side == "long"
+
+
 def test_equal_close_skips() -> None:
     cur = _c("2026-08-17 10:30:00", 104.0, 120.0, 90.0, 104.0)
     side, why = s16_bar_decision(PREV, cur)
     assert side is None
     assert "C=prev" in why
+
+
+def test_tiny_down_wick_does_not_flip_when_gap_3() -> None:
+    """Down-close U=2 Lw=3 FLIPs at gap=0, holds at gap=3."""
+    candles = [
+        PREV,
+        _c("2026-08-17 10:30:00", 104.0, 130.0, 80.0, 90.0),  # C<prev upper wick → short @ 90
+        _c("2026-08-17 11:00:00", 89.0, 91.0, 85.0, 88.0),  # C<prev U=2 Lw=3
+        _c("2026-08-17 11:30:00", 88.0, 89.0, 87.0, 88.5),
+    ]
+    r0 = simulate_s16(
+        candles, tf="toy:g0", lots=1, fees=False, session_filter=False, min_wick_gap=0
+    )
+    r3 = simulate_s16(
+        candles, tf="toy:g3", lots=1, fees=False, session_filter=False, min_wick_gap=3
+    )
+    assert r0.n_trades == 2
+    assert r0.trades[0].side == "SHORT"
+    assert r0.trades[0].exit_time == "2026-08-17 11:00:00"
+    assert r0.trades[1].side == "LONG"
+    assert r3.n_trades == 1
+    assert r3.trades[0].side == "SHORT"
+    assert r3.trades[0].entry_time == "2026-08-17 10:30:00"
+    assert r3.trades[0].exit_time == "2026-08-17 11:30:00"
+    skip_row = walk_candles(candles, min_wick_gap=3)[1]
+    assert skip_row["action"] == "skip"
+    assert skip_row["wick_gap"] == 1.0
 
 
 def test_enter_then_flip() -> None:
@@ -116,6 +167,10 @@ if __name__ == "__main__":
     test_down_close_uses_wick_not_hhhl()
     test_down_close_upper_wick_short()
     test_equal_close_skips()
+    test_tiny_wick_gap_skips_when_gap_is_3()
+    test_clear_wick_still_fires_with_gap_3()
+    test_up_close_ignores_wick_gap()
+    test_tiny_down_wick_does_not_flip_when_gap_3()
     test_enter_then_flip()
     test_skip_bar_holds_open_trade()
     test_walk_marks_flip()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
One formula, backtest only. Not paper. Not live.

**S16 — same finished candle vs previous close**

- **C > previous close** → HH/LL only: HH+green LONG, LL+red SHORT (wicks ignored)
- **C < previous close** → wick only, **and** `|upper − lower| ≥ min_wick_gap`:
  lower>upper LONG, upper>lower SHORT (HH/LL ignored)
- **C = previous close** → skip
- Opposite signal **FLIP** at that bar’s close

Default sweeps **wick gaps 0, 3, 5, 10** on every TF (1m … 1d). Output is a compare block per TF (trades, win%, after-tax ₹, fees, max DD, Δ vs g0) plus day-by-day for every gap. Also writes `gap_compare.csv`.

**On the VM** (skip the 30m bar dump so the paste is just the compare):

```bash
cd ~/goldpetal-repo
git fetch origin
git checkout cursor/s16-hhhl-wick-a4b2
git pull origin cursor/s16-hhhl-wick-a4b2
cd goldpetal
./venv/bin/python backtest_s16_hhhl_wick.py --db data/ticks.db --lots 100 --session --fees --print-bars ''
```

Keep `DRY_RUN=true`. Paste from `=== Wick-gap compare` through the day-by-day grid.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e92370bb-ed6a-433d-8b83-fe612227a4b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e92370bb-ed6a-433d-8b83-fe612227a4b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

