### PR TITLE
S17 close×high×body bucket scan (research only)

### DIFF
--- a/goldpetal/backtest_s17_close_high_body.py
+++ b/goldpetal/backtest_s17_close_high_body.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Count S17 close×high×body buckets. Research only. No book yet.
+
+  ./venv/bin/python backtest_s17_close_high_body.py --db data/ticks.db --session
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+from backtest_hhhl_candles import TIMEFRAMES
+from backtest_wick_candles import build_ohlc_candles, load_ltp_rows
+from s17_close_high_body import (
+    FORMULA,
+    LISTED_BUCKETS,
+    MISSING_BUCKETS,
+    USER_COLUMNS,
+    BucketCount,
+    bucket_kind,
+    counts_as_dict,
+    ordered_bucket_names,
+    tally_rows,
+    walk_candles,
+)
+
+DEFAULT_TICK_TFS = ",".join(n for n, _ in TIMEFRAMES)
+
+
+def _parse_tick_tfs(raw: str) -> list[tuple[str, int]]:
+    by = {n: m for n, m in TIMEFRAMES}
+    out: list[tuple[str, int]] = []
+    for name in (x.strip().lower() for x in raw.split(",") if x.strip()):
+        if name == "30":
+            name = "30m"
+        if name in {"d", "day", "daily"}:
+            name = "1d"
+        if name not in by:
+            raise SystemExit(f"unknown tf {name!r}. have: {', '.join(by)}")
+        out.append((name, by[name]))
+    if not out:
+        raise SystemExit("no timeframes")
+    return out
+
+
+def write_walk_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "time",
+        "open",
+        "high",
+        "low",
+        "close",
+        "prev_close",
+        "prev_high",
+        "prev_low",
+        "close_vs",
+        "high_vs",
+        "low_vs",
+        "body",
+        "bucket",
+        "kind",
+        "upper",
+        "lower",
+        "wick_gap",
+        "wick",
+        "hhhl",
+        "agree",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        w.writerows(rows)
+
+
+def _print_completeness() -> None:
+    print(FORMULA, flush=True)
+    print("Your six columns:", flush=True)
+    for col, close_s, high_s, body in USER_COLUMNS:
+        print(f"  {col}.  {close_s}  {high_s}  {body}  →  {LISTED_BUCKETS[int(col) - 1]}", flush=True)
+    print(
+        "Same grid, not listed yet:  "
+        + ", ".join(MISSING_BUCKETS)
+        + "  | leftover: C=pC, H=pH, C=O",
+        flush=True,
+    )
+    print("No LONG/SHORT assigned. Lows + wicks are recorded only.", flush=True)
+    print(flush=True)
+
+
+def print_bucket_table(tf: str, rows: list[dict[str, Any]], counts: dict[str, BucketCount]) -> None:
+    n_all = len(rows) or 1
+    print(f"=== {tf}  bars={len(rows)}  (session bars vs previous candle) ===")
+    print(
+        f"{'kind':<8}  {'bucket':<14}  {'n':>5}  {'%':>5}  "
+        f"{'HL/LL/eq':>12}  {'wick L/S/—':>12}  {'hhhl L/S/—':>12}  "
+        f"{'and':>4}  {'or':>4}  {'fight':>5}  {'Δ≥3/5/10':>11}"
+    )
+    print("-" * 122)
+    for name in ordered_bucket_names(counts):
+        b = counts.get(name) or BucketCount()
+        if b.n == 0 and bucket_kind(name) == "leftover":
+            continue
+        pct = 100.0 * b.n / n_all
+        print(
+            f"{bucket_kind(name):<8}  {name:<14}  {b.n:5d}  {pct:4.1f}%  "
+            f"{b.n_hl:3d}/{b.n_ll:<3d}/{b.n_low_eq:<3d}  "
+            f"{b.n_wick_long:3d}/{b.n_wick_short:<3d}/{b.n_wick_none:<3d}  "
+            f"{b.n_hhhl_long:3d}/{b.n_hhhl_short:<3d}/{b.n_hhhl_none:<3d}  "
+            f"{b.n_agree:4d}  {b.n_or:4d}  {b.n_fight:5d}  "
+            f"{b.n_gap_ge3:3d}/{b.n_gap_ge5:<3d}/{b.n_gap_ge10:<3d}"
+        )
+    listed_n = sum((counts.get(k) or BucketCount()).n for k in LISTED_BUCKETS)
+    missing_n = sum((counts.get(k) or BucketCount()).n for k in MISSING_BUCKETS)
+    leftover_n = len(rows) - listed_n - missing_n
+    print(
+        f"{'total':<8}  {'listed/miss/left':<14}  "
+        f"{listed_n:5d}/{missing_n:<3d}/{leftover_n:<3d}   "
+        f"and=HHHL∧wick  or=HHHL∨wick  Δ=|U−L|",
+        flush=True,
+    )
+    print(flush=True)
+
+
+def print_listed_matrix(summary: dict[str, Any]) -> None:
+    print("=== Listed columns across TFs (n bars) ===")
+    labels = [
+        "1 up_hh_g",
+        "2 up_hh_r",
+        "3 dn_lh_g",
+        "4 dn_lh_r",
+        "5 dn_hh_g",
+        "6 up_lh_r",
+    ]
+    hdr = f"{'tf':>5}  " + "  ".join(f"{lab:>10}" for lab in labels) + f"  {'miss':>5}  {'left':>5}"
+    print(hdr)
+    for tf, block in summary.items():
+        listed = block["listed"]
+        bits = [f"{listed[k]:10d}" for k in LISTED_BUCKETS]
+        print(
+            f"{tf:>5}  "
+            + "  ".join(bits)
+            + f"  {block['missing_n']:5d}  {block['leftover_n']:5d}"
+        )
+    print()
+
+
+def print_bar_dump(tf: str, rows: list[dict[str, Any]], *, leftover: bool) -> None:
+    shown = rows if leftover else [r for r in rows if r["kind"] != "leftover"]
+    print(
+        f"=== {tf} bars "
+        + ("(all kinds)" if leftover else "(listed + missing; leftover hidden)")
+        + " ===",
+        flush=True,
+    )
+    for row in shown:
+        print(
+            f"{row['time']:<22} O={row['open']:.1f} H={row['high']:.1f} "
+            f"L={row['low']:.1f} C={row['close']:.1f}  "
+            f"{row['kind']:<8} {row['bucket']:<14}  "
+            f"low={row['low_vs']:<3}  U={row['upper']:.1f} Lw={row['lower']:.1f}  "
+            f"hhhl={row['hhhl']:<5} wick={row['wick']:<5} {row['agree']}",
+            flush=True,
+        )
+    print(flush=True)
+
+
+def run_from_ticks(
+    db: Path,
+    *,
+    session_filter: bool,
+    tfs: list[tuple[str, int]],
+    drop_last: bool,
+    out_dir: Path,
+    print_bars_tf: str | None,
+    print_leftover: bool,
+) -> dict[str, Any]:
+    ltp = load_ltp_rows(db)
+    if not ltp:
+        raise SystemExit(f"no ticks in {db}")
+    summary: dict[str, Any] = {}
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for name, minutes in tfs:
+        candles = build_ohlc_candles(ltp, minutes)
+        if drop_last and len(candles) >= 2:
+            candles = candles[:-1]
+        use_session = session_filter and name != "1d"
+        rows = walk_candles(candles, session_filter=use_session)
+        counts = tally_rows(rows)
+        print_bucket_table(name, rows, counts)
+        write_walk_csv(out_dir / f"{name}_walk.csv", rows)
+        if print_bars_tf == name:
+            print_bar_dump(name, rows, leftover=print_leftover)
+        listed_n = sum((counts.get(k) or BucketCount()).n for k in LISTED_BUCKETS)
+        missing_n = sum((counts.get(k) or BucketCount()).n for k in MISSING_BUCKETS)
+        summary[name] = {
+            "n_bars": len(rows),
+            "listed": {k: (counts.get(k) or BucketCount()).n for k in LISTED_BUCKETS},
+            "missing": {k: (counts.get(k) or BucketCount()).n for k in MISSING_BUCKETS},
+            "missing_n": missing_n,
+            "leftover_n": len(rows) - listed_n - missing_n,
+            "counts": counts_as_dict(counts),
+        }
+    print_listed_matrix(summary)
+    (out_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2), encoding="utf-8"
+    )
+    return summary
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--db", type=Path, default=Path("data/ticks.db"))
+    ap.add_argument("--tf", default="")
+    ap.add_argument("--session", action="store_true", default=True)
+    ap.add_argument("--no-session", action="store_true")
+    ap.add_argument("--keep-last", action="store_true")
+    ap.add_argument("--print-bars", default="", help="print this TF's bars (or 30m)")
+    ap.add_argument(
+        "--print-leftover",
+        action="store_true",
+        help="include C=pC / H=pH / doji rows in the bar dump",
+    )
+    ap.add_argument("--out", type=Path, default=Path("data/backtests/s17_close_high_body"))
+    args = ap.parse_args()
+    session_filter = bool(args.session) and not bool(args.no_session)
+    print_bars_tf = (args.print_bars or "").strip().lower() or None
+    if print_bars_tf == "30":
+        print_bars_tf = "30m"
+
+    _print_completeness()
+    print(
+        f"session={session_filter}  source={args.db}  counts only — not a book",
+        flush=True,
+    )
+    tfs = _parse_tick_tfs(args.tf or DEFAULT_TICK_TFS)
+    run_from_ticks(
+        args.db,
+        session_filter=session_filter,
+        tfs=tfs,
+        drop_last=not args.keep_last,
+        out_dir=args.out,
+        print_bars_tf=print_bars_tf,
+        print_leftover=bool(args.print_leftover),
+    )
+    print(f"wrote {args.out}", flush=True)
+    print("Not paper. Not live. Add LONG/SHORT per column next.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/goldpetal/backtest_s17_close_high_body.py
+++ b/goldpetal/backtest_s17_close_high_body.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
-"""Count S17 close×high×body buckets. Research only. No book yet.
+"""Count S17 close×high×body buckets, then settle hhhl/wick/and/or books.
 
-  ./venv/bin/python backtest_s17_close_high_body.py --db data/ticks.db --session
+Research only. Do not paper or live-enable until a 100-lot + fees row is picked.
+
+  ./venv/bin/python backtest_s17_close_high_body.py --db data/ticks.db --session --lots 100 --fees
 """
 
 from __future__ import annotations
@@ -12,9 +14,10 @@ import json
 from pathlib import Path
 from typing import Any
 
-from backtest_hhhl_candles import TIMEFRAMES
-from backtest_wick_candles import build_ohlc_candles, load_ltp_rows
+from backtest_hhhl_candles import TIMEFRAMES, make_charge_cfg, print_by_day, write_outputs
+from backtest_wick_candles import build_ohlc_candles, load_ltp_rows, print_wick_summary
 from s17_close_high_body import (
+    BOOK_MODES,
     FORMULA,
     LISTED_BUCKETS,
     MISSING_BUCKETS,
@@ -23,11 +26,22 @@ from s17_close_high_body import (
     bucket_kind,
     counts_as_dict,
     ordered_bucket_names,
+    simulate_s17,
     tally_rows,
     walk_candles,
 )
 
 DEFAULT_TICK_TFS = ",".join(n for n, _ in TIMEFRAMES)
+
+
+def _parse_books(raw: str) -> list[str]:
+    out: list[str] = []
+    for bit in (x.strip().lower() for x in raw.split(",") if x.strip()):
+        if bit not in BOOK_MODES:
+            raise SystemExit(f"unknown book {bit!r}. have: {', '.join(BOOK_MODES)}")
+        if bit not in out:
+            out.append(bit)
+    return out
 
 
 def _parse_tick_tfs(raw: str) -> list[tuple[str, int]]:
@@ -87,7 +101,7 @@ def _print_completeness() -> None:
         + "  | leftover: C=pC, H=pH, C=O",
         flush=True,
     )
-    print("No LONG/SHORT assigned. Lows + wicks are recorded only.", flush=True)
+    print("Leftover (C=pC / H=pH / doji) is skipped in every book.", flush=True)
     print(flush=True)
 
 
@@ -177,12 +191,18 @@ def run_from_ticks(
     out_dir: Path,
     print_bars_tf: str | None,
     print_leftover: bool,
+    lots: float,
+    fees: bool,
+    books: list[str],
+    min_wick_gap: float,
 ) -> dict[str, Any]:
     ltp = load_ltp_rows(db)
     if not ltp:
         raise SystemExit(f"no ticks in {db}")
     summary: dict[str, Any] = {}
     out_dir.mkdir(parents=True, exist_ok=True)
+    cfg = make_charge_cfg(fees=fees, lots=lots)
+    book_results = []
     for name, minutes in tfs:
         candles = build_ohlc_candles(ltp, minutes)
         if drop_last and len(candles) >= 2:
@@ -204,7 +224,29 @@ def run_from_ticks(
             "leftover_n": len(rows) - listed_n - missing_n,
             "counts": counts_as_dict(counts),
         }
+        for mode in books:
+            r = simulate_s17(
+                candles,
+                tf=f"{name}:{mode}",
+                mode=mode,
+                lots=lots,
+                fees=fees,
+                session_filter=use_session,
+                charge_cfg=cfg,
+                min_wick_gap=min_wick_gap,
+            )
+            book_results.append(r)
     print_listed_matrix(summary)
+    if book_results:
+        print_wick_summary(
+            book_results,
+            title=(
+                f"S17 books  lots={lots:g}  fees={fees}  wick_gap={min_wick_gap:g}"
+            ),
+        )
+        day_rows = [r for r in book_results if r.tf.startswith(("30m:", "45m:", "1h:", "2h:", "3h:"))]
+        print_by_day(day_rows or book_results)
+        write_outputs(book_results, out_dir)
     (out_dir / "summary.json").write_text(
         json.dumps(summary, indent=2), encoding="utf-8"
     )
@@ -224,16 +266,29 @@ def main() -> None:
         action="store_true",
         help="include C=pC / H=pH / doji rows in the bar dump",
     )
+    ap.add_argument("--lots", type=float, default=100.0)
+    ap.add_argument("--fees", action="store_true", default=True)
+    ap.add_argument("--no-fees", action="store_true")
+    ap.add_argument(
+        "--book",
+        default="hhhl,wick,and,or",
+        help="FLIP books to settle, or '' for counts only",
+    )
+    ap.add_argument("--wick-gap", type=float, default=3.0)
     ap.add_argument("--out", type=Path, default=Path("data/backtests/s17_close_high_body"))
     args = ap.parse_args()
     session_filter = bool(args.session) and not bool(args.no_session)
+    fees = bool(args.fees) and not bool(args.no_fees)
     print_bars_tf = (args.print_bars or "").strip().lower() or None
     if print_bars_tf == "30":
         print_bars_tf = "30m"
+    books = _parse_books(args.book) if (args.book or "").strip() else []
 
     _print_completeness()
     print(
-        f"session={session_filter}  source={args.db}  counts only — not a book",
+        f"session={session_filter}  lots={args.lots:g}  fees={fees}  "
+        f"books={','.join(books) or 'none'}  wick_gap={args.wick_gap:g}  "
+        f"source={args.db}",
         flush=True,
     )
     tfs = _parse_tick_tfs(args.tf or DEFAULT_TICK_TFS)
@@ -245,9 +300,13 @@ def main() -> None:
         out_dir=args.out,
         print_bars_tf=print_bars_tf,
         print_leftover=bool(args.print_leftover),
+        lots=args.lots,
+        fees=fees,
+        books=books,
+        min_wick_gap=float(args.wick_gap),
     )
     print(f"wrote {args.out}", flush=True)
-    print("Not paper. Not live. Add LONG/SHORT per column next.", flush=True)
+    print("Not paper. Not live. Pick a TF:book row first.", flush=True)
 
 
 if __name__ == "__main__":

--- a/goldpetal/s17_close_high_body.py
+++ b/goldpetal/s17_close_high_body.py
@@ -1,0 +1,243 @@
+"""S17 research: classify a finished bar by close / high / body.
+
+Not paper. Not live. No LONG/SHORT yet — counts only, then you add sides later.
+
+c = this finished candle, p = previous finished candle.
+
+The six gates you listed (strict > / <):
+
+  1. C>pC  H>pH  C>O     up_hh_green
+  2. C>pC  H>pH  C<O     up_hh_red
+  3. C<pC  H<pH  C>O     dn_lh_green
+  4. C<pC  H<pH  C<O     dn_lh_red
+  5. C<pC  H>pH  C>O     dn_hh_green
+  6. C>pC  H<pH  C<O     up_lh_red
+
+Same 2×2×2 grid, two cells not listed (add later if you want them):
+
+  7. C>pC  H<pH  C>O     up_lh_green
+  8. C<pC  H>pH  C<O     dn_hh_red
+
+Leftover under strict > / <: C=pC, H=pH, C=O.
+
+Inside every bucket we only *record* (not trade):
+  lows vs previous low (HL / LL / equal)
+  wick (upper vs lower)
+  S12 HH+green / LL+red
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from backtest_hhhl_candles import Candle, in_session
+from wick_candles import wick_measure
+
+LISTED_BUCKETS: tuple[str, ...] = (
+    "up_hh_green",
+    "up_hh_red",
+    "dn_lh_green",
+    "dn_lh_red",
+    "dn_hh_green",
+    "up_lh_red",
+)
+
+MISSING_BUCKETS: tuple[str, ...] = (
+    "up_lh_green",
+    "dn_hh_red",
+)
+
+USER_COLUMNS: tuple[tuple[str, str, str, str], ...] = (
+    ("1", "C>pC", "H>pH", "green"),
+    ("2", "C>pC", "H>pH", "red"),
+    ("3", "C<pC", "H<pH", "green"),
+    ("4", "C<pC", "H<pH", "red"),
+    ("5", "C<pC", "H>pH", "green"),
+    ("6", "C>pC", "H<pH", "red"),
+)
+
+FORMULA = (
+    "Wait for the candle to finish. Classify vs previous close, previous high, "
+    "and body (C vs O). Six listed gates; two more cells in the same grid; "
+    "equals are leftover. Record lows + wicks. No LONG/SHORT yet."
+)
+
+
+def _cmp_tag(cur: float, prev: float, gt: str, lt: str) -> str:
+    if cur > prev:
+        return gt
+    if cur < prev:
+        return lt
+    return "eq"
+
+
+def hhhl_side(prev: Candle, cur: Candle) -> str | None:
+    want_long = cur.high > prev.high and cur.close > cur.open
+    want_short = cur.low < prev.low and cur.close < cur.open
+    if want_long and not want_short:
+        return "long"
+    if want_short and not want_long:
+        return "short"
+    return None
+
+
+def wick_raw_side(cur: Candle) -> str | None:
+    return wick_measure(cur.open, cur.high, cur.low, cur.close).dominant
+
+
+def classify_bar(prev: Candle, cur: Candle) -> dict[str, Any]:
+    """One finished candle vs previous → bucket + structure/wick notes."""
+    close_vs = _cmp_tag(cur.close, prev.close, "up", "dn")
+    high_vs = _cmp_tag(cur.high, prev.high, "hh", "lh")
+    low_vs = _cmp_tag(cur.low, prev.low, "hl", "ll")
+    if cur.close > cur.open:
+        body = "green"
+    elif cur.close < cur.open:
+        body = "red"
+    else:
+        body = "doji"
+
+    bucket = f"{close_vs}_{high_vs}_{body}"
+    if bucket in LISTED_BUCKETS:
+        kind = "listed"
+    elif bucket in MISSING_BUCKETS:
+        kind = "missing"
+    else:
+        kind = "leftover"
+
+    m = wick_measure(cur.open, cur.high, cur.low, cur.close)
+    hh = hhhl_side(prev, cur)
+    wk = wick_raw_side(cur)
+    if hh and wk and hh == wk:
+        agree = "agree"
+    elif hh and wk and hh != wk:
+        agree = "fight"
+    else:
+        agree = "none"
+
+    return {
+        "time": cur.time,
+        "open": cur.open,
+        "high": cur.high,
+        "low": cur.low,
+        "close": cur.close,
+        "prev_close": prev.close,
+        "prev_high": prev.high,
+        "prev_low": prev.low,
+        "close_vs": close_vs,
+        "high_vs": high_vs,
+        "low_vs": low_vs,
+        "body": body,
+        "bucket": bucket,
+        "kind": kind,
+        "upper": round(m.upper, 2),
+        "lower": round(m.lower, 2),
+        "wick_gap": round(abs(m.upper - m.lower), 2),
+        "wick": wk or "none",
+        "hhhl": hh or "none",
+        "agree": agree,
+    }
+
+
+def walk_candles(
+    candles: list[Candle],
+    *,
+    session_filter: bool = False,
+    market_open: str = "09:00",
+    market_close: str = "23:30",
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for i in range(1, len(candles)):
+        prev, cur = candles[i - 1], candles[i]
+        if session_filter and not in_session(
+            cur, open_hhmm=market_open, close_hhmm=market_close
+        ):
+            continue
+        out.append(classify_bar(prev, cur))
+    return out
+
+
+@dataclass
+class BucketCount:
+    n: int = 0
+    n_hl: int = 0
+    n_ll: int = 0
+    n_low_eq: int = 0
+    n_wick_long: int = 0
+    n_wick_short: int = 0
+    n_wick_none: int = 0
+    n_hhhl_long: int = 0
+    n_hhhl_short: int = 0
+    n_hhhl_none: int = 0
+    n_agree: int = 0
+    n_fight: int = 0
+    n_or: int = 0
+    n_gap_ge3: int = 0
+    n_gap_ge5: int = 0
+    n_gap_ge10: int = 0
+    wick_gap_sum: float = 0.0
+
+
+def tally_rows(rows: list[dict[str, Any]]) -> dict[str, BucketCount]:
+    by: dict[str, BucketCount] = defaultdict(BucketCount)
+    for row in rows:
+        b = by[str(row["bucket"])]
+        b.n += 1
+        if row["low_vs"] == "hl":
+            b.n_hl += 1
+        elif row["low_vs"] == "ll":
+            b.n_ll += 1
+        else:
+            b.n_low_eq += 1
+        if row["wick"] == "long":
+            b.n_wick_long += 1
+        elif row["wick"] == "short":
+            b.n_wick_short += 1
+        else:
+            b.n_wick_none += 1
+        if row["hhhl"] == "long":
+            b.n_hhhl_long += 1
+        elif row["hhhl"] == "short":
+            b.n_hhhl_short += 1
+        else:
+            b.n_hhhl_none += 1
+        if row["agree"] == "agree":
+            b.n_agree += 1
+        elif row["agree"] == "fight":
+            b.n_fight += 1
+        if row["hhhl"] != "none" or row["wick"] != "none":
+            b.n_or += 1
+        gap = float(row["wick_gap"])
+        b.wick_gap_sum += gap
+        if gap >= 3:
+            b.n_gap_ge3 += 1
+        if gap >= 5:
+            b.n_gap_ge5 += 1
+        if gap >= 10:
+            b.n_gap_ge10 += 1
+    return dict(by)
+
+
+def counts_as_dict(counts: dict[str, BucketCount]) -> dict[str, dict[str, float]]:
+    out: dict[str, dict[str, float]] = {}
+    for name, b in counts.items():
+        row = asdict(b)
+        row["wick_gap_avg"] = (b.wick_gap_sum / b.n) if b.n else 0.0
+        out[name] = row
+    return out
+
+
+def bucket_kind(name: str) -> str:
+    if name in LISTED_BUCKETS:
+        return "listed"
+    if name in MISSING_BUCKETS:
+        return "missing"
+    return "leftover"
+
+
+def ordered_bucket_names(counts: dict[str, BucketCount]) -> list[str]:
+    names = list(LISTED_BUCKETS) + list(MISSING_BUCKETS)
+    extra = sorted(k for k in counts if k not in names)
+    return names + extra

--- a/goldpetal/s17_close_high_body.py
+++ b/goldpetal/s17_close_high_body.py
@@ -1,6 +1,6 @@
 """S17 research: classify a finished bar by close / high / body.
 
-Not paper. Not live. No LONG/SHORT yet — counts only, then you add sides later.
+Not paper. Not live.
 
 c = this finished candle, p = previous finished candle.
 
@@ -18,12 +18,13 @@ Same 2×2×2 grid, two cells not listed (add later if you want them):
   7. C>pC  H<pH  C>O     up_lh_green
   8. C<pC  H>pH  C<O     dn_hh_red
 
-Leftover under strict > / <: C=pC, H=pH, C=O.
+Leftover under strict > / <: C=pC, H=pH, C=O. Books skip leftover.
 
-Inside every bucket we only *record* (not trade):
-  lows vs previous low (HL / LL / equal)
-  wick (upper vs lower)
-  S12 HH+green / LL+red
+Books (FLIP, fill at this bar's close), only on listed+missing:
+  hhhl = S12 (HH+green LONG, LL+red SHORT)
+  wick = raw wick if |U−L| ≥ min_wick_gap
+  and  = both same side
+  or   = either side, skip if they fight
 """
 
 from __future__ import annotations
@@ -32,7 +33,9 @@ from collections import defaultdict
 from dataclasses import asdict, dataclass
 from typing import Any
 
-from backtest_hhhl_candles import Candle, in_session
+from backtest_hhhl_candles import Candle, Trade, in_session, make_charge_cfg
+from backtest_wick_candles import _tf_result_from_trades
+from charges import ChargeConfig, apply_charges_and_tax
 from wick_candles import wick_measure
 
 LISTED_BUCKETS: tuple[str, ...] = (
@@ -61,8 +64,11 @@ USER_COLUMNS: tuple[tuple[str, str, str, str], ...] = (
 FORMULA = (
     "Wait for the candle to finish. Classify vs previous close, previous high, "
     "and body (C vs O). Six listed gates; two more cells in the same grid; "
-    "equals are leftover. Record lows + wicks. No LONG/SHORT yet."
+    "equals are leftover. Record lows + wicks. Books (research): leftover skip; "
+    "hhhl / wick / AND / OR-skip-fight. Fill at close. FLIP."
 )
+
+BOOK_MODES: tuple[str, ...] = ("hhhl", "wick", "and", "or")
 
 
 def _cmp_tag(cur: float, prev: float, gt: str, lt: str) -> str:
@@ -241,3 +247,159 @@ def ordered_bucket_names(counts: dict[str, BucketCount]) -> list[str]:
     names = list(LISTED_BUCKETS) + list(MISSING_BUCKETS)
     extra = sorted(k for k in counts if k not in names)
     return names + extra
+
+
+def s17_bar_decision(
+    prev: Candle,
+    cur: Candle,
+    *,
+    mode: str = "hhhl",
+    min_wick_gap: float = 3.0,
+) -> tuple[str | None, str]:
+    """One finished candle → ('long'|'short'|None, why). Leftover always skip."""
+    if mode not in BOOK_MODES:
+        raise ValueError(f"unknown book mode {mode!r}. have: {', '.join(BOOK_MODES)}")
+    row = classify_bar(prev, cur)
+    if row["kind"] == "leftover":
+        return None, f"leftover {row['bucket']}"
+    hh = None if row["hhhl"] == "none" else str(row["hhhl"])
+    wk = None if row["wick"] == "none" else str(row["wick"])
+    if float(row["wick_gap"]) < float(min_wick_gap):
+        wk = None
+    tag = row["bucket"]
+    if mode == "hhhl":
+        if hh:
+            return hh, f"{tag} hhhl {hh}"
+        return None, f"{tag} no hhhl"
+    if mode == "wick":
+        if wk:
+            return wk, f"{tag} wick {wk}"
+        return None, f"{tag} no wick"
+    if mode == "and":
+        if hh and wk and hh == wk:
+            return hh, f"{tag} and {hh}"
+        return None, f"{tag} and skip"
+    # or: take the one signal; skip fights
+    if hh and wk and hh != wk:
+        return None, f"{tag} or fight skip"
+    side = hh or wk
+    if side:
+        return side, f"{tag} or {side}"
+    return None, f"{tag} or skip"
+
+
+def _close_leg(
+    *,
+    tf: str,
+    side: str,
+    entry_time: str,
+    entry_px: float,
+    exit_c: Candle,
+    cfg: ChargeConfig,
+) -> Trade:
+    if side == "LONG":
+        pts = exit_c.close - entry_px
+        order_side = "BUY"
+    else:
+        pts = entry_px - exit_c.close
+        order_side = "SELL"
+    settled = apply_charges_and_tax(
+        pts,
+        cfg,
+        side=order_side,
+        entry_price=entry_px,
+        exit_price=exit_c.close,
+    )
+    return Trade(
+        tf=tf,
+        side=side,
+        entry_time=entry_time,
+        entry_px=entry_px,
+        exit_time=exit_c.time,
+        exit_px=exit_c.close,
+        gross_pts=float(pts) * float(cfg.lot_size),
+        gross_pnl_inr=float(settled["gross_pnl"]),
+        after_tax_pnl_inr=float(settled["pnl_after_tax"]),
+        fees_inr=float(settled["charges"]),
+        lots=float(cfg.lot_size),
+    )
+
+
+def simulate_s17(
+    candles: list[Candle],
+    *,
+    tf: str,
+    mode: str = "hhhl",
+    lots: float = 100.0,
+    fees: bool = True,
+    session_filter: bool = True,
+    market_open: str = "09:00",
+    market_close: str = "23:30",
+    charge_cfg: ChargeConfig | None = None,
+    min_wick_gap: float = 3.0,
+) -> Any:
+    """FLIP book on listed+missing buckets. Fill at signal-bar close."""
+    cfg = charge_cfg or make_charge_cfg(fees=fees, lots=lots)
+    trades: list[Trade] = []
+    side: str | None = None
+    entry_px = 0.0
+    entry_time = ""
+
+    def close_trade(exit_c: Candle) -> None:
+        nonlocal side, entry_px, entry_time
+        assert side is not None
+        trades.append(
+            _close_leg(
+                tf=tf,
+                side=side,
+                entry_time=entry_time,
+                entry_px=entry_px,
+                exit_c=exit_c,
+                cfg=cfg,
+            )
+        )
+        side = None
+
+    for i in range(1, len(candles)):
+        prev, cur = candles[i - 1], candles[i]
+        sess_ok = (not session_filter) or in_session(
+            cur, open_hhmm=market_open, close_hhmm=market_close
+        )
+        if side is not None and session_filter and not sess_ok:
+            close_trade(cur)
+            continue
+        if session_filter and not sess_ok:
+            continue
+
+        want, _why = s17_bar_decision(
+            prev, cur, mode=mode, min_wick_gap=min_wick_gap
+        )
+        want_long = want == "long"
+        want_short = want == "short"
+
+        if side == "LONG":
+            if want_short:
+                close_trade(cur)
+                side = "SHORT"
+                entry_px = cur.close
+                entry_time = cur.time
+            continue
+        if side == "SHORT":
+            if want_long:
+                close_trade(cur)
+                side = "LONG"
+                entry_px = cur.close
+                entry_time = cur.time
+            continue
+        if want_long:
+            side = "LONG"
+            entry_px = cur.close
+            entry_time = cur.time
+        elif want_short:
+            side = "SHORT"
+            entry_px = cur.close
+            entry_time = cur.time
+
+    if side is not None and candles:
+        close_trade(candles[-1])
+    return _tf_result_from_trades(tf, len(candles), trades)

--- a/goldpetal/test_s17_close_high_body.py
+++ b/goldpetal/test_s17_close_high_body.py
@@ -1,0 +1,121 @@
+"""S17: six close×high×body columns. Counts only. Not a book."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from backtest_hhhl_candles import Candle
+from control_state import ALL_STRATEGY_NAMES
+from s17_close_high_body import (
+    LISTED_BUCKETS,
+    MISSING_BUCKETS,
+    classify_bar,
+    tally_rows,
+    walk_candles,
+)
+
+
+def _c(t: str, o: float, h: float, l: float, c: float) -> Candle:
+    return Candle(t, o, h, l, c)
+
+
+PREV = _c("2026-08-17 10:00:00", 100.0, 105.0, 99.0, 104.0)
+
+
+def _cls(o: float, h: float, l: float, c: float) -> dict:
+    return classify_bar(PREV, _c("2026-08-17 10:30:00", o, h, l, c))
+
+
+def test_six_listed_columns() -> None:
+    assert _cls(100.0, 120.0, 100.0, 110.0)["bucket"] == "up_hh_green"  # 1 C>pC H>pH green
+    assert _cls(112.0, 120.0, 100.0, 110.0)["bucket"] == "up_hh_red"  # 2
+    assert _cls(100.0, 104.0, 90.0, 103.0)["bucket"] == "dn_lh_green"  # 3
+    assert _cls(103.0, 104.0, 90.0, 100.0)["bucket"] == "dn_lh_red"  # 4
+    assert _cls(100.0, 110.0, 90.0, 102.0)["bucket"] == "dn_hh_green"  # 5
+    assert _cls(104.8, 104.9, 104.2, 104.4)["bucket"] == "up_lh_red"  # 6
+    for row in (
+        _cls(100.0, 120.0, 100.0, 110.0),
+        _cls(112.0, 120.0, 100.0, 110.0),
+        _cls(100.0, 104.0, 90.0, 103.0),
+        _cls(103.0, 104.0, 90.0, 100.0),
+        _cls(100.0, 110.0, 90.0, 102.0),
+        _cls(104.8, 104.9, 104.2, 104.4),
+    ):
+        assert row["kind"] == "listed"
+        assert row["bucket"] in LISTED_BUCKETS
+
+
+def test_two_missing_grid_cells() -> None:
+    g = _cls(100.0, 104.8, 99.0, 104.5)  # C>pC H<pH green
+    r = _cls(110.0, 120.0, 90.0, 100.0)  # C<pC H>pH red
+    assert g["bucket"] == "up_lh_green"
+    assert r["bucket"] == "dn_hh_red"
+    assert g["kind"] == r["kind"] == "missing"
+    assert g["bucket"] in MISSING_BUCKETS
+    assert r["bucket"] in MISSING_BUCKETS
+
+
+def test_equals_are_leftover() -> None:
+    eq_c = _cls(100.0, 120.0, 90.0, 104.0)
+    eq_h = _cls(100.0, 105.0, 90.0, 104.5)
+    doji = _cls(110.0, 120.0, 90.0, 110.0)
+    assert eq_c["kind"] == "leftover"
+    assert eq_h["kind"] == "leftover"
+    assert doji["kind"] == "leftover"
+    assert eq_c["close_vs"] == "eq"
+    assert eq_h["high_vs"] == "eq"
+    assert doji["body"] == "doji"
+
+
+def test_records_low_and_wick() -> None:
+    row = _cls(100.0, 120.0, 80.0, 110.0)  # HH green, LL, long lower wick
+    assert row["bucket"] == "up_hh_green"
+    assert row["low_vs"] == "ll"
+    assert row["wick"] == "long"
+    assert row["hhhl"] == "long"
+    assert row["agree"] == "agree"
+
+
+def test_hhhl_and_wick_can_fight() -> None:
+    row = _cls(114.0, 120.0, 113.0, 115.0)  # HH green, no LL, upper wick
+    assert row["hhhl"] == "long"
+    assert row["wick"] == "short"
+    assert row["agree"] == "fight"
+    assert row["low_vs"] == "hl"
+
+
+def test_tally_and_or() -> None:
+    rows = walk_candles(
+        [
+            PREV,
+            _c("2026-08-17 10:30:00", 100.0, 120.0, 80.0, 110.0),
+            _c("2026-08-17 11:00:00", 110.0, 111.0, 109.0, 110.5),
+        ]
+    )
+    by = tally_rows(rows)
+    agree = by["up_hh_green"]
+    assert agree.n == 1
+    assert agree.n_agree == 1
+    assert agree.n_or == 1
+    assert rows[1]["bucket"] == "up_lh_green"
+    assert rows[1]["kind"] == "missing"
+
+
+def test_not_wired_to_paper_or_station() -> None:
+    assert "S17_CLOSE_HIGH_BODY" not in ALL_STRATEGY_NAMES
+    station = (Path(__file__).resolve().parent / "station.html").read_text(encoding="utf-8")
+    assert "S17_CLOSE_HIGH_BODY" not in station
+    runner = (Path(__file__).resolve().parent / "run_strategy.py").read_text(encoding="utf-8")
+    assert "s17_close_high_body" not in runner
+    assert "ENABLE_S17" not in runner
+
+
+if __name__ == "__main__":
+    test_six_listed_columns()
+    test_two_missing_grid_cells()
+    test_equals_are_leftover()
+    test_records_low_and_wick()
+    test_hhhl_and_wick_can_fight()
+    test_tally_and_or()
+    test_not_wired_to_paper_or_station()
+    print("ALL test_s17_close_high_body OK")

--- a/goldpetal/test_s17_close_high_body.py
+++ b/goldpetal/test_s17_close_high_body.py
@@ -1,4 +1,4 @@
-"""S17: six close×high×body columns. Counts only. Not a book."""
+"""S17: six close×high×body columns. Counts + hhhl/wick/and/or books."""
 
 from __future__ import annotations
 
@@ -10,6 +10,8 @@ from s17_close_high_body import (
     LISTED_BUCKETS,
     MISSING_BUCKETS,
     classify_bar,
+    s17_bar_decision,
+    simulate_s17,
     tally_rows,
     walk_candles,
 )
@@ -101,6 +103,56 @@ def test_tally_and_or() -> None:
     assert rows[1]["kind"] == "missing"
 
 
+def test_books_skip_leftover() -> None:
+    cur = _c("2026-08-17 10:30:00", 100.0, 120.0, 90.0, 104.0)  # C=pC
+    for mode in ("hhhl", "wick", "and", "or"):
+        side, why = s17_bar_decision(PREV, cur, mode=mode)
+        assert side is None
+        assert "leftover" in why
+
+
+def test_col1_hhhl_long_wick_may_fight() -> None:
+    # HH green, upper wick
+    cur = _c("2026-08-17 10:30:00", 114.0, 120.0, 113.0, 115.0)
+    hh, _ = s17_bar_decision(PREV, cur, mode="hhhl")
+    wk, _ = s17_bar_decision(PREV, cur, mode="wick", min_wick_gap=0)
+    both, why_and = s17_bar_decision(PREV, cur, mode="and", min_wick_gap=0)
+    either, why_or = s17_bar_decision(PREV, cur, mode="or", min_wick_gap=0)
+    assert hh == "long"
+    assert wk == "short"
+    assert both is None
+    assert "and skip" in why_and
+    assert either is None
+    assert "fight" in why_or
+
+
+def test_missing_up_lh_green_wick_only() -> None:
+    cur = _c("2026-08-17 10:30:00", 100.0, 104.8, 90.0, 104.5)
+    hh, _ = s17_bar_decision(PREV, cur, mode="hhhl")
+    wk, _ = s17_bar_decision(PREV, cur, mode="wick", min_wick_gap=0)
+    either, _ = s17_bar_decision(PREV, cur, mode="or", min_wick_gap=0)
+    assert hh is None
+    assert wk == "long"
+    assert either == "long"
+
+
+def test_flip_hhhl_book() -> None:
+    candles = [
+        PREV,
+        _c("2026-08-17 10:30:00", 100.0, 120.0, 100.0, 110.0),  # col1 LONG @ 110
+        _c("2026-08-17 11:00:00", 108.0, 109.0, 80.0, 90.0),  # col4 LL+red SHORT @ 90
+        _c("2026-08-17 11:30:00", 90.0, 91.0, 89.0, 90.5),
+    ]
+    r = simulate_s17(
+        candles, tf="toy:hhhl", mode="hhhl", lots=1, fees=False, session_filter=False
+    )
+    assert r.n_trades == 2
+    assert r.trades[0].side == "LONG"
+    assert r.trades[0].entry_px == 110.0
+    assert r.trades[0].exit_px == 90.0
+    assert r.trades[1].side == "SHORT"
+
+
 def test_not_wired_to_paper_or_station() -> None:
     assert "S17_CLOSE_HIGH_BODY" not in ALL_STRATEGY_NAMES
     station = (Path(__file__).resolve().parent / "station.html").read_text(encoding="utf-8")
@@ -117,5 +169,9 @@ if __name__ == "__main__":
     test_records_low_and_wick()
     test_hhhl_and_wick_can_fight()
     test_tally_and_or()
+    test_books_skip_leftover()
+    test_col1_hhhl_long_wick_may_fight()
+    test_missing_up_lh_green_wick_only()
+    test_flip_hhhl_book()
     test_not_wired_to_paper_or_station()
     print("ALL test_s17_close_high_body OK")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Research only. Not paper. Not live.

**Counts (VM tape, session):** only **column 1** (`up_hh_green`) and **column 4** (`dn_lh_red`) are common. Columns 2/3/5/6 are almost empty on 30m+. The two cells you left for later (`up_lh_green`, `dn_hh_red`) are 25–30% of 30m/1h bars — add them. On column 1, wick **fights** HHHL more often than it agrees (upper wick on a green HH).

**Books now in the CLI** (FLIP, fill at close, leftover skip, wick gap ≥ 3):

- `hhhl` — HH+green LONG, LL+red SHORT
- `wick` — raw wick
- `and` — both same side
- `or` — either side, skip if they fight

```bash
cd ~/goldpetal-repo
git pull origin cursor/s17-close-high-body-a4b2
cd goldpetal
./venv/bin/python backtest_s17_close_high_body.py --db data/ticks.db --session --lots 100 --fees
```

Paste the `=== S17 books` summary (skip the count tables if you already sent them). Keep `DRY_RUN=true`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e92370bb-ed6a-433d-8b83-fe612227a4b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e92370bb-ed6a-433d-8b83-fe612227a4b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

