### PR TITLE
S13 rides until Gold Petal rollover; S16 is session-only

### DIFF
--- a/goldpetal/.env.example
+++ b/goldpetal/.env.example
@@ -14,6 +14,8 @@ DRY_RUN=true
 # EOD_FLATTEN_INTRADAY=true
 # EOD_FLATTEN_MINUTES=5
 ROLLOVER_DAYS=5
+# Switch to next-month Gold Petal this many calendar days before front expiry.
+# S13 flattens the front-month book on the last front session, then trades next month.
 INTERVAL_MINUTES=30
 # Market hours (IST), Mon-Fri only
 MARKET_OPEN=09:00
@@ -28,7 +30,7 @@ NET_SURGE_FOLD=2.0
 ENABLE_S1=false
 ENABLE_S2=false
 ENABLE_S3=false
-ENABLE_S4=true
+ENABLE_S4=false
 ENABLE_S5=true
 ENABLE_S6=false
 # S8 ALIGN / zigzag
@@ -42,15 +44,17 @@ ENABLE_S11=true
 ENABLE_S12=false
 ENABLE_S14=false
 ENABLE_S15=false
-# S13 daily S16 — last 15m of this day. Hold until opposite. Same formula as S16 1h.
+# S13 daily S16 — last 15m of this day. Hold the trend until opposite OR monthly rollover.
 # C>prevC → HH+green LONG / LL+red SHORT. C<prevC → wick g0. C=prevC skip. FLIP.
-# Backtest with S4 first: python backtest_s4_s13_daily_swing.py --db data/ticks.db --lots 100 --fees
+# ROLLOVER_DAYS=5: flatten the front-month book on the last front session, then trade next month.
+# Backtest: python backtest_s4_s13_daily_swing.py --from-angel --from 2026-08-02 --lots 100 --fees
 ENABLE_S13=true
 S13_ENTRY_MINUTES_BEFORE_CLOSE=15
 S13_MIN_WICK_GAP=0
 S13_ALLOW_LONG=true
 S13_ALLOW_SHORT=true
-# S16 1h HH/LL-or-wick (paper). Wait for the 1h candle to finish.
+# S16 1h HH/LL-or-wick (paper). Wait for the 1h candle to finish. Intraday only.
+# First fill is the first finished 1h of the session. Flatten at MARKET_CLOSE. Never overnight.
 # C>prevC → HH+green LONG / LL+red SHORT (wicks ignored).
 # C<prevC → wick g0 (lower>upper LONG, upper>lower SHORT). C=prevC skip. FLIP.
 ENABLE_S16=true
@@ -64,9 +68,7 @@ ML_BUY_PROB=0.58
 ML_SHORT_PROB=0.42
 ML_MIN_HOLD_SEC=30
 ML_EVERY_N_TICKS=5
-# S4 daily HH/LL swing (old S13). Last 15m of this day. Hold until opposite HH/LL.
-# FLIP. Never next-open flatten — this is the multi-day/week ride.
-# Backtest first: python backtest_s4_s13_daily_swing.py --db data/ticks.db --lots 100 --fees
+# S4 daily HH/LL swing is research-only (Angel/ticks pick was S13). Leave off.
 S4_ENTRY_MINUTES_BEFORE_CLOSE=15
 S4_ALLOW_LONG=true
 S4_ALLOW_SHORT=true

--- a/goldpetal/analytics/VM_DESK.md
+++ b/goldpetal/analytics/VM_DESK.md
@@ -77,54 +77,38 @@ git pull origin cursor/s14-wick-length-a4b2
 ./scripts/run_desk_vm.sh --restart
 ```
 
-## S4 daily HH/LL swing (paper after backtest)
+## S4 daily HH/LL swing (research only)
 
-Old S13 HH/LL on the **day** candle. Confirm only in the last 15 minutes
-before `MARKET_CLOSE`. **Hold the trend across days and weeks** until the
-opposite HH+green / LL+red. FLIP. Never flatten at next open. Never EOD flatten.
-
-S13 is the same clock with the **new** S16 close-vs-prev formula.
-
-Backtest both books at 100 lots + fees **before** leaving them on paper
-(fill analog = finished 1d close ≈ last-15m). Not `backtest_s4_hhhl_daily.py`
-(that still has min_range / next-open overnight).
+Angel + ticks daily backtest picked **S13**, not S4. Leave S4 off.
 
 ```bash
-cd ~/goldpetal-repo/goldpetal
-./venv/bin/python backtest_s4_s13_daily_swing.py --db data/ticks.db --lots 100 --fees
-# or: ./venv/bin/python backtest_s4_s13_daily_swing.py --from-angel --from 2026-08-02 --lots 100 --fees
-```
-
-Paste the compare table and day walk. Keep `DRY_RUN=true`. Do not paper until a row is picked.
-
-```bash
-ENABLE_S4=true
-S4_ENTRY_MINUTES_BEFORE_CLOSE=15
+ENABLE_S4=false
 ```
 
 Overnight ML (`weekly_s4.sh` / `strategy_overnight.py`) is research-only.
 
-## S13 daily S16 (paper after backtest)
+## S13 daily S16 (paper — the day-by-day book)
 
 S16 close-vs-prev on the **day** candle vs the previous day. Confirm only in the
 **last 15 minutes before MARKET_CLOSE** (never the next day's open).
-Fill at last-15m LTP. Overnight hold until the opposite signal.
+Fill at last-15m LTP. Hold the trend until the opposite S16 signal.
 
-- C > prevC → HH/LL only (HH+green LONG, LL+red SHORT). Wicks ignored.
-- C < prevC → wick only, gap 0 (lower>upper LONG, upper>lower SHORT). HH/LL ignored.
-- C = prevC → skip
-- FLIP if already the other side. No min_range, no fakeout close-beyond.
-
-S16 1h stays a separate book (`S16_HHHL_WICK_1H`).
+Monthly contract (existing `ROLLOVER_DAYS=5` rule in `symbols.py`):
+- Front month until 5 calendar days before expiry, then the feed is **next month**.
+- S13 **closes** the front-month book on the last front session (do not hold through the switch).
+- After the switch it trades the **next-month** contract as a new trend.
 
 ```bash
 # in .env
 ENABLE_S13=true
+ENABLE_S4=false
 S13_ENTRY_MINUTES_BEFORE_CLOSE=15
 S13_MIN_WICK_GAP=0
+ROLLOVER_DAYS=5
+DRY_RUN=true
 ```
 
-Restart supervise after pull. Look for `hold-until-opposite` on S4/S13 in `data/strategy_run.log`.
+Restart supervise after pull. Look for `hold-until-opposite` and `contract=` on S13, and `DRY_RUN=true`.
 
 ## Restart / orphan / EOD safety (intraday)
 
@@ -154,7 +138,7 @@ ENABLE_S15=false
 
 Research helpers (`backtest_s14_tick.py`, `explain_s14_candles.py`) still exist for old tape.
 
-## S16 1h HH/LL-or-wick (paper)
+## S16 1h HH/LL-or-wick (paper — intraday)
 
 Wait for the **1h** candle to finish. Same closed bar vs previous close:
 
@@ -162,7 +146,9 @@ Wait for the **1h** candle to finish. Same closed bar vs previous close:
   C < prevC → wick only, gap 0: lower>upper LONG, upper>lower SHORT
   C = prevC → skip
 
-FLIP at that bar's close. Fill at close. Session flatten at EOD. Keep `DRY_RUN=true`.
+FLIP at that bar's close. Fill at close. **Intraday only:** first fill is the
+first finished 1h of the session; flatten at `MARKET_CLOSE` (and leftover at
+next `MARKET_OPEN`). Never overnight. Keep `DRY_RUN=true`.
 
 ```bash
 ENABLE_S16=true
@@ -281,7 +267,7 @@ Slim `.env` (only these strategies load into RAM):
 ENABLE_S1=false
 ENABLE_S2=false
 ENABLE_S3=false
-ENABLE_S4=true
+ENABLE_S4=false
 ENABLE_S5=true
 ENABLE_S6=false
 ENABLE_S8=true

--- a/goldpetal/analytics/env_bridge.py
+++ b/goldpetal/analytics/env_bridge.py
@@ -91,7 +91,7 @@ SLIM_ENABLE_DEFAULTS: dict[str, str] = {
     "ENABLE_S1": "false",
     "ENABLE_S2": "false",
     "ENABLE_S3": "false",
-    "ENABLE_S4": "true",
+    "ENABLE_S4": "false",
     "ENABLE_S5": "true",
     "ENABLE_S6": "false",
     "ENABLE_S8": "true",

--- a/goldpetal/portfolio.py
+++ b/goldpetal/portfolio.py
@@ -99,7 +99,8 @@ class PortfolioConfig:
 def portfolio_from_env() -> PortfolioConfig:
     """Load enable flags from env.
 
-    Slim paper default: S4, S5, S8, S11, S13, S16 only (saves RAM).
+    Slim paper default: S5, S8, S11, S13, S16 (S4 off — Angel/ticks daily
+    swing pick was S13).
     """
     def on(key: str, default: str) -> bool:
         return os.getenv(key, default).strip().lower() in {"1", "true", "yes", "y"}
@@ -111,7 +112,7 @@ def portfolio_from_env() -> PortfolioConfig:
         enabled.add("S2_BALANCE")
     if on("ENABLE_S3", "false"):
         enabled.add("S3_ML")
-    if on("ENABLE_S4", "true"):
+    if on("ENABLE_S4", "false"):
         enabled.add("S4_OVERNIGHT")
     if on("ENABLE_S5", "true"):
         enabled.add("S5_MINEDGE")
@@ -132,7 +133,6 @@ def portfolio_from_env() -> PortfolioConfig:
 
     if not enabled:
         enabled = {
-            "S4_OVERNIGHT",
             "S5_MINEDGE",
             "S8_NET_ZIGZAG",
             "S11_DISCOVERED",

--- a/goldpetal/position_safety.py
+++ b/goldpetal/position_safety.py
@@ -40,6 +40,9 @@ INTRADAY_RESTORE = (
     "S11_DISCOVERED",
 )
 
+# S16 is a same-session book: do not restore yesterday's position overnight.
+SESSION_CLOSE_OVERNIGHT = frozenset({"S16_HHHL_WICK_1H"})
+
 # S4/S13 are multi-day/week holds. Retired S12/S14/S15 last-minute confirm overlapped EOD.
 EOD_FLATTEN_SKIP = frozenset(
     {
@@ -141,7 +144,7 @@ def apply_position_to_strategy(strategy_obj: Any, open_pos: OpenPosition) -> boo
     strategy_obj.position = open_pos.side  # type: ignore[assignment]
     if hasattr(strategy_obj, "entry_price"):
         strategy_obj.entry_price = open_pos.entry_price
-    if name in {"S4_OVERNIGHT", "S13_HHHL_DAY"} and open_pos.time_label:
+    if name in {"S4_OVERNIGHT", "S13_HHHL_DAY", "S16_HHHL_WICK_1H"} and open_pos.time_label:
         if hasattr(strategy_obj, "entry_date"):
             strategy_obj.entry_date = str(open_pos.time_label)[:10]
     if hasattr(strategy_obj, "_save_state"):
@@ -176,7 +179,8 @@ def startup_reconcile(
         "messages": [str, ...],
       }
     """
-    del now  # reserved for future stale-age rules
+    now_ist = (now or datetime.now(IST)).astimezone(IST)
+    today = now_ist.strftime("%Y-%m-%d")
     mode = (mode or restart_mode()).lower()
     restored: list[dict[str, Any]] = []
     closes: list[dict[str, Any]] = []
@@ -192,6 +196,23 @@ def startup_reconcile(
         if open_pos is None:
             continue
         obj = strategies.get(name)
+
+        if name in SESSION_CLOSE_OVERNIGHT and str(open_pos.time_label)[:10] != today:
+            closes.append(
+                {
+                    "strategy": name,
+                    "side": open_pos.side,
+                    "entry_price": open_pos.entry_price,
+                    "time_label": open_pos.time_label,
+                    "cmp": open_pos.cmp,
+                    "reason": "S16 session leftover auto-CLOSE (intraday — flatten overnight)",
+                }
+            )
+            messages.append(
+                f"SESSION CLOSE {name} was_{open_pos.side} since {open_pos.time_label} "
+                f"(not restoring overnight)"
+            )
+            continue
 
         if mode == "close":
             closes.append(

--- a/goldpetal/run_strategy.py
+++ b/goldpetal/run_strategy.py
@@ -302,6 +302,18 @@ def run_once(
     print(f"Symbol   : {symbol}", flush=True)
     print(f"Token    : {token}", flush=True)
     print(f"Expiry   : {contract['expiry']}", flush=True)
+    print(
+        f"Rollover : front={contract.get('front_month_expiry')} "
+        f"next={contract.get('next_month_expiry')} "
+        f"days_left={contract.get('days_to_front_expiry')} "
+        f"rolled={contract.get('rolled')} "
+        f"(switch {contract.get('rollover_days')}d before front expiry)",
+        flush=True,
+    )
+    if hasattr(strategy_s13, "set_contract"):
+        strategy_s13.set_contract(contract)
+    if hasattr(strategy_s4, "set_contract"):
+        strategy_s4.set_contract(contract)
     print(f"Interval : {interval} minutes", flush=True)
     print(
         f"Portfolio: enabled={sorted(portfolio.enabled)} "
@@ -375,13 +387,13 @@ def run_once(
         flush=True,
     )
     print(
-        f"S13      : daily S16 swing (hold until opposite) "
+        f"S13      : daily S16 swing (hold until opposite / flatten on rollover) "
         f"[{'ON' if portfolio.is_enabled(strategy_s13.name) else 'OFF'}] "
         f"{strategy_s13.status_line}",
         flush=True,
     )
     print(
-        f"S16      : 1h HH/LL-or-wick on close "
+        f"S16      : 1h HH/LL-or-wick, intraday flatten at close "
         f"[{'ON' if portfolio.is_enabled(strategy_s16.name) else 'OFF'}] "
         f"{strategy_s16.status_line}",
         flush=True,
@@ -1410,8 +1422,32 @@ def run_once(
             # S10: legacy 30m always zigzag (+₹42k MTF paper path)
             emit_s10_if_changed(now, message)
             # S13: daily S16 close-vs-prev (last 15m of the signal day)
+            # Once a day, re-read the rollover rule so S13 flattens the front
+            # month before the feed switches to next month.
+            day_key = now.astimezone(IST).strftime("%Y-%m-%d")
+            if state.get("roll_day") != day_key:
+                state["roll_day"] = day_key
+                try:
+                    fresh = find_goldpetal_futures()
+                except Exception as exc:
+                    fresh = None
+                    print(f"Rollover check skip: {type(exc).__name__}: {exc}", flush=True)
+                if fresh is not None:
+                    if hasattr(strategy_s13, "set_contract"):
+                        strategy_s13.set_contract(fresh)
+                    if hasattr(strategy_s4, "set_contract"):
+                        strategy_s4.set_contract(fresh)
+                    if str(fresh.get("token")) != str(token):
+                        state["roll_reconnect"] = True
+                        print(
+                            f"ROLLOVER: {symbol} → {fresh.get('symbol')} "
+                            f"(front {fresh.get('front_month_expiry')} "
+                            f"days_left={fresh.get('days_to_front_expiry')}). "
+                            "Flatten S13, then reconnect the next-month feed.",
+                            flush=True,
+                        )
             emit_s13_if_changed(now, message)
-            # S16: 1h close-vs-prev HH/LL or wick, FLIP at bar close
+            # S16: 1h close-vs-prev HH/LL or wick, FLIP at bar close; flatten at EOD
             emit_s16_if_changed(now, message)
 
             # EOD flatten intraday (S5/S8/S12/…) in last N minutes before MARKET_CLOSE
@@ -1431,6 +1467,8 @@ def run_once(
                     obj.position = "flat"
                     if hasattr(obj, "entry_price"):
                         obj.entry_price = None
+                    if hasattr(obj, "entry_date"):
+                        obj.entry_date = None
                     ts = now.isoformat(timespec="seconds")
                     _record_signal(
                         time_label=ts,
@@ -1464,6 +1502,12 @@ def run_once(
                             "runner": "run_strategy",
                         }
                     )
+
+            if state.pop("roll_reconnect", False):
+                try:
+                    sws.close()
+                except Exception as exc:
+                    print(f"Rollover reconnect close failed: {exc}", flush=True)
 
             # S1: 30-min bars
             if now >= state["next_bar_at"]:
@@ -1554,7 +1598,7 @@ def main() -> None:
     print(f"S16_HHHL_WICK_1H: {strategy_s16.status_line}", flush=True)
     print(
         f"Portfolio enabled={sorted(portfolio.enabled)} "
-        f"(slim default S4/S5/S8/S11/S13/S16 — set ENABLE_S* in .env)",
+        f"(slim default S5/S8/S11/S13/S16 — S4 off, set ENABLE_S* in .env)",
         flush=True,
     )
 

--- a/goldpetal/strategy_hhhl_day.py
+++ b/goldpetal/strategy_hhhl_day.py
@@ -3,13 +3,18 @@
 Confirm only in the last 15 minutes of *this* day (`MARKET_CLOSE` 23:30 →
 23:15–23:30). Never the next day's open. Fill at last-15m LTP. FLIP if
 already the other side. Stay in until the opposite signal (no next-open
-kill, no EOD flatten).
+kill, no EOD flatten), **or** until the Gold Petal monthly rollover.
+
+Rollover (same `ROLLOVER_DAYS=5` policy as `symbols.find_goldpetal_futures`):
+the feed switches to next month from 5 days before front expiry. S13
+closes the front-month book on the last front session (and on a token
+switch), then trades the next-month contract as a new trend.
 
 Two paper books share this engine:
 
-  S4_OVERNIGHT  — old S13 HH/LL only (HH+green LONG, LL+red SHORT).
-  S13_HHHL_DAY  — S16 close-vs-prev on the day candle:
-                    C>prevC → HH/LL; C<prevC → wick g0; C=prevC skip.
+  S4_OVERNIGHT  — old S13 HH/LL only (research; paper default off).
+  S13_HHHL_DAY  — S16 close-vs-prev on the day candle (the day-by-day book).
+
 
 No min_range. No fakeout close-beyond. S16 1h stays its own book.
 Overnight ML (strategy_overnight) is research-only — not the paper S4.
@@ -29,6 +34,7 @@ from zoneinfo import ZoneInfo
 from backtest_hhhl_candles import Candle
 from s16_hhhl_wick import hhhl_side, s16_bar_decision
 from strategy import Position, SignalResult
+from symbols import s13_roll_intent
 from wick_candles import wick_measure
 
 IST = ZoneInfo("Asia/Kolkata")
@@ -115,6 +121,8 @@ class HhhlDayOvernightStrategy:
         self._acted_date: str | None = None
         self.market_open = self._parse_hhmm(self.cfg.market_open)
         self.market_close = self._parse_hhmm(self.cfg.market_close)
+        self._contract: dict[str, Any] | None = None
+        self.contract_symbol: str | None = None
         self._load_state()
         # Always re-read ticks so a restart does not freeze today's H/L
         # at the first print of the day (s13_state.json is only a snapshot).
@@ -153,7 +161,8 @@ class HhhlDayOvernightStrategy:
         return (
             f"{rule} confirm={c.entry_minutes_before_close}m_before_close FLIP "
             f"L={c.allow_long} S={c.allow_short} "
-            f"{prev} {today} pos={self.position}"
+            f"{prev} {today} pos={self.position} "
+            f"contract={self.contract_symbol or '-'}"
         )
 
     def _load_state(self) -> None:
@@ -166,6 +175,7 @@ class HhhlDayOvernightStrategy:
         self.position = raw.get("side", "flat")  # type: ignore[assignment]
         self.entry_price = raw.get("entry_price")
         self.entry_date = raw.get("entry_date")
+        self.contract_symbol = raw.get("contract_symbol") or None
         acted = raw.get("acted_date")
         if isinstance(acted, str) and acted:
             self._acted_date = acted
@@ -292,6 +302,7 @@ class HhhlDayOvernightStrategy:
             "entry_price": self.entry_price,
             "entry_date": self.entry_date,
             "acted_date": self._acted_date,
+            "contract_symbol": self.contract_symbol,
             "prev_day": None,
             "today": None,
         }
@@ -464,6 +475,85 @@ class HhhlDayOvernightStrategy:
         else:
             self.last_skip = "watching_equal_close"
 
+    def set_contract(self, contract: dict[str, Any] | None) -> None:
+        """Bind the live Gold Petal contract (front vs next per ROLLOVER_DAYS)."""
+        self._contract = dict(contract) if contract else None
+
+    def _reset_book_for_new_contract(self) -> None:
+        self.prev_day = None
+        self._day = None
+        self._acted_today = False
+        self._acted_date = None
+
+    def _flatten(self, px: float, why: str) -> SignalResult | None:
+        if self.position == "flat":
+            return None
+        prev = self.position
+        self.position = "flat"
+        self.entry_price = None
+        self.entry_date = None
+        self.last_signal = "CLOSE"
+        self._save_state()
+        return SignalResult(
+            action="CLOSE",
+            position_after="flat",
+            price_delta=None,
+            net=None,
+            net_delta=None,
+            prev_net_delta=None,
+            reason=f"{self._reason_tag()} CLOSE {prev}→flat {why}",
+        )
+
+    def _roll_on_tick(self, now: datetime, px: float) -> SignalResult | None:
+        c = self._contract
+        if not c:
+            return None
+        symbol = str(c.get("symbol") or "")
+        intent = s13_roll_intent(
+            held_symbol=self.contract_symbol,
+            trade_symbol=symbol,
+            rolled=bool(c.get("rolled")),
+            days_to_front_expiry=int(c.get("days_to_front_expiry") or 0),
+            rollover_days=int(c.get("rollover_days") or 5),
+            in_position=self.position in {"long", "short"},
+        )
+        today = now.strftime("%Y-%m-%d")
+        if intent in {"flatten_switch", "reset_switch"}:
+            sig = self._flatten(
+                px,
+                f"contract switch {self.contract_symbol}→{symbol} "
+                f"ROLLOVER_DAYS={c.get('rollover_days')}",
+            )
+            self._reset_book_for_new_contract()
+            self.contract_symbol = symbol or None
+            self._mark_acted(today)
+            self.last_skip = "rolled_new_contract"
+            self._save_state()
+            return sig
+        if intent == "flatten_last_front":
+            sig = self._flatten(
+                px,
+                f"last front-month session "
+                f"days_to_front={c.get('days_to_front_expiry')} "
+                f"ROLLOVER_DAYS={c.get('rollover_days')} — avoid near expiry",
+            )
+            self._mark_acted(today)
+            self.last_skip = "avoid_front_roll"
+            self._save_state()
+            return sig
+        if intent == "block_last_front":
+            self.last_skip = "avoid_front_roll"
+            if symbol and self.contract_symbol != symbol:
+                self.contract_symbol = symbol
+                self._save_state()
+            return None
+        if symbol and self.contract_symbol != symbol:
+            self.contract_symbol = symbol
+            self._save_state()
+        if self.last_skip in {"avoid_front_roll", "rolled_new_contract"}:
+            self.last_skip = None
+        return None
+
     def on_tick(
         self, now: datetime, ltp: float, message: dict[str, Any] | None = None
     ) -> SignalResult | None:
@@ -471,6 +561,11 @@ class HhhlDayOvernightStrategy:
         now = now.astimezone(IST)
         today = now.strftime("%Y-%m-%d")
         px = float(ltp)
+        rolled = self._roll_on_tick(now, px)
+        if rolled is not None:
+            return rolled
+        if self.last_skip == "avoid_front_roll":
+            return None
         self._update_day_bar(today, px)
 
         if self._acted_date == today:

--- a/goldpetal/strategy_s16.py
+++ b/goldpetal/strategy_s16.py
@@ -13,6 +13,8 @@ on that **same** closed bar vs the previous closed bar:
 
 FLIP if already the other side. Fill at this bar's close.
 No range skip. No bald-body. No open=high/low (that is S14).
+Intraday only: first fill is the first finished 1h of the session;
+flatten at MARKET_CLOSE (and leftover at next MARKET_OPEN). Never overnight.
 Not live-unlocked. Paper 100 lots ≠ live.
 """
 
@@ -42,6 +44,8 @@ class S16Config:
     min_wick_gap: float = 0.0
     allow_long: bool = True
     allow_short: bool = True
+    market_open: str = "09:00"
+    market_close: str = "23:30"
 
 
 class S16HhhlWickStrategy:
@@ -53,6 +57,7 @@ class S16HhhlWickStrategy:
         self.cfg = cfg or S16Config()
         self.position: Position = "flat"
         self.entry_price: float | None = None
+        self.entry_date: str | None = None
         self.last_skip: str | None = None
         self._bar_key: datetime | None = None
         self._bar_o = self._bar_h = self._bar_l = self._bar_c = None
@@ -89,6 +94,7 @@ class S16HhhlWickStrategy:
         return (
             f"TF={c.bar_minutes}m gap={c.min_wick_gap:g} "
             f"C>prev→HH/LL C<prev→wick FLIP on 1h close "
+            f"intraday {c.market_open}-{c.market_close} flatten-at-close "
             f"{self.bar_debug} skip={self.last_skip or '-'} pos={self.position}"
         )
 
@@ -98,6 +104,75 @@ class S16HhhlWickStrategy:
         mins = int((ts - midnight).total_seconds() // 60)
         block = (mins // max(1, self.cfg.bar_minutes)) * max(1, self.cfg.bar_minutes)
         return midnight + timedelta(minutes=block)
+
+    def _hhmm(self, raw: str) -> tuple[int, int]:
+        h, m = raw.strip().split(":")
+        return int(h), int(m)
+
+    def _in_session(self, now: datetime) -> bool:
+        if now.weekday() >= 5:
+            return False
+        oh, om = self._hhmm(self.cfg.market_open)
+        ch, cm = self._hhmm(self.cfg.market_close)
+        t = now.hour * 60 + now.minute
+        return (oh * 60 + om) <= t <= (ch * 60 + cm)
+
+    def _bar_started_in_session(self, bar: Candle) -> bool:
+        try:
+            dt = datetime.strptime(bar.time[:19], "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            return False
+        oh, om = self._hhmm(self.cfg.market_open)
+        ch, cm = self._hhmm(self.cfg.market_close)
+        t = dt.hour * 60 + dt.minute
+        return (oh * 60 + om) <= t < (ch * 60 + cm)
+
+    def _session_flatten_why(self, now: datetime) -> str | None:
+        if self.position == "flat":
+            return None
+        if now.weekday() >= 5:
+            return "weekend flatten"
+        oh, om = self._hhmm(self.cfg.market_open)
+        ch, cm = self._hhmm(self.cfg.market_close)
+        t = now.hour * 60 + now.minute
+        if t >= ch * 60 + cm:
+            return f"session close {self.cfg.market_close}"
+        if t < oh * 60 + om:
+            return f"preopen leftover before {self.cfg.market_open}"
+        today = now.strftime("%Y-%m-%d")
+        if self.entry_date and self.entry_date < today:
+            return f"overnight leftover {self.entry_date} flatten at {self.cfg.market_open}"
+        return None
+
+    def _flatten(self, px: float, why: str) -> SignalResult:
+        prev = self.position
+        self.position = "flat"
+        self.entry_price = None
+        self.entry_date = None
+        self.last_skip = why
+        return SignalResult(
+            action="CLOSE",
+            position_after="flat",
+            price_delta=None,
+            net=None,
+            net_delta=None,
+            prev_net_delta=None,
+            reason=f"{self.name} CLOSE {prev}→flat {why}",
+        )
+
+    def _maybe_decide_closed(self, closed: Candle | None, now: datetime) -> SignalResult | None:
+        if closed is None:
+            return None
+        result = None
+        if (
+            self._in_session(now)
+            and closed.time[:10] == now.strftime("%Y-%m-%d")
+            and self._bar_started_in_session(closed)
+        ):
+            result = self._decide_closed(closed)
+        if self._bar_started_in_session(closed):
+            self._prev = closed
+        return result
 
     def release_decision_lock(self) -> None:
         """No intra-bar lock; kept so the runner's entry-gate retry path is a no-op."""
@@ -134,9 +209,12 @@ class S16HhhlWickStrategy:
                 self.position = pos  # type: ignore[assignment]
                 cmp = row["cmp"]
                 self.entry_price = float(cmp) if cmp is not None else None
+                tl = str(row["time_label"] or "")
+                self.entry_date = tl[:10] if tl else None
             elif action == "CLOSE" or pos == "flat":
                 self.position = "flat"
                 self.entry_price = None
+                self.entry_date = None
         except Exception:
             return
 
@@ -214,17 +292,23 @@ class S16HhhlWickStrategy:
         now = now.astimezone(IST)
         key = self._floor_bar(now)
         px = float(ltp)
+        flatten_why = self._session_flatten_why(now)
 
         if self._bar_key is None:
             self._reset_bar(key, px)
+            if flatten_why:
+                return self._flatten(px, flatten_why)
             self.last_skip = "waiting_1h_close"
             return None
 
         if key != self._bar_key:
             closed = self._closed_candle()
-            result = self._decide_closed(closed)
-            self._prev = closed
+            result = None if flatten_why else self._maybe_decide_closed(closed, now)
+            if flatten_why and closed is not None and self._bar_started_in_session(closed):
+                self._prev = closed
             self._reset_bar(key, px)
+            if flatten_why:
+                return self._flatten(px, flatten_why)
             return result
 
         assert self._bar_h is not None and self._bar_l is not None
@@ -232,6 +316,8 @@ class S16HhhlWickStrategy:
         self._bar_l = min(self._bar_l, px)
         self._bar_c = px
         self._bar_n += 1
+        if flatten_why:
+            return self._flatten(px, flatten_why)
         self.last_skip = "waiting_1h_close"
         return None
 
@@ -286,6 +372,7 @@ class S16HhhlWickStrategy:
             action = "SHORT"
             extra = f"U={m.upper:.1f}>L={m.lower:.1f}"
         self.entry_price = float(cur.close)
+        self.entry_date = (cur.time[:10] if cur.time else None)
         kind = "FLIP" if prev != "flat" else "enter"
         prev_c = f" prevC={self._prev.close:.1f}" if self._prev is not None else ""
         return SignalResult(
@@ -327,5 +414,7 @@ def s16_from_env() -> S16HhhlWickStrategy:
         min_wick_gap=float(os.getenv("S16_MIN_WICK_GAP", "0")),
         allow_long=_env_flag("S16_ALLOW_LONG", True),
         allow_short=_env_flag("S16_ALLOW_SHORT", True),
+        market_open=os.getenv("MARKET_OPEN", "09:00"),
+        market_close=os.getenv("MARKET_CLOSE", "23:30"),
     )
     return S16HhhlWickStrategy(cfg)

--- a/goldpetal/symbols.py
+++ b/goldpetal/symbols.py
@@ -9,7 +9,11 @@ from pathlib import Path
 from typing import Any
 
 import requests
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover
+    def load_dotenv(*_args, **_kwargs):
+        return False
 
 SCRIP_MASTER_URL = (
     "https://margincalculator.angelone.in/OpenAPI_File/files/OpenAPIScripMaster.json"
@@ -86,6 +90,64 @@ def _list_goldpetal_futures(force_refresh: bool = False) -> list[tuple[datetime,
     return contracts
 
 
+def choose_goldpetal_contract(
+    upcoming: list[tuple[datetime, dict[str, Any]]],
+    *,
+    today: datetime,
+    rollover_days: int,
+) -> dict[str, Any]:
+    """Pick front vs next month. Switch when ``days_left <= rollover_days``."""
+    if not upcoming:
+        raise RuntimeError("No upcoming GOLDPETAL futures contracts found")
+    today0 = today.replace(hour=0, minute=0, second=0, microsecond=0)
+    front_exp, front = upcoming[0]
+    nxt_exp, nxt = (upcoming[1] if len(upcoming) > 1 else (None, None))
+    front0 = front_exp.replace(hour=0, minute=0, second=0, microsecond=0)
+    days_left = (front0 - today0).days
+    should_roll = days_left <= int(rollover_days) and nxt is not None
+    if should_roll:
+        chosen_exp, chosen, rolled = nxt_exp, nxt, True
+    else:
+        chosen_exp, chosen, rolled = front_exp, front, False
+    assert chosen_exp is not None and chosen is not None
+    return _contract_payload(
+        chosen_exp,
+        chosen,
+        rolled=rolled,
+        rollover_days=int(rollover_days),
+        front_expiry=front.get("expiry", ""),
+        next_expiry=(nxt.get("expiry") if nxt else None),
+        days_to_front_expiry=days_left,
+    )
+
+
+def s13_roll_intent(
+    *,
+    held_symbol: str | None,
+    trade_symbol: str,
+    rolled: bool,
+    days_to_front_expiry: int,
+    rollover_days: int,
+    in_position: bool,
+) -> str:
+    """What S13 should do given the existing ROLLOVER_DAYS policy.
+
+    ``flatten_switch`` — feed already on next month; close the old-contract book.
+    ``reset_switch`` — same, but already flat (still drop old-day OHLC).
+    ``flatten_last_front`` — last session on the expiring front month; close it.
+    ``block_last_front`` — same session, stay out of the front month.
+    ``trade`` — ride the trend on the active contract.
+    """
+    held = str(held_symbol or "").strip()
+    trade = str(trade_symbol or "").strip()
+    if held and trade and held != trade:
+        return "flatten_switch" if in_position else "reset_switch"
+    last_front = (not bool(rolled)) and int(days_to_front_expiry) <= int(rollover_days) + 1
+    if last_front:
+        return "flatten_last_front" if in_position else "block_last_front"
+    return "trade"
+
+
 def _contract_payload(
     chosen_exp: datetime,
     chosen: dict[str, Any],
@@ -125,31 +187,10 @@ def find_goldpetal_futures(force_refresh: bool = False) -> dict[str, Any]:
     contracts = _list_goldpetal_futures(force_refresh=force_refresh)
     today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
     upcoming = [(exp, row) for exp, row in contracts if exp >= today]
-    if not upcoming:
-        raise RuntimeError("No upcoming GOLDPETAL futures contracts found")
-
-    front_exp, front = upcoming[0]
-    next_exp, nxt = (upcoming[1] if len(upcoming) > 1 else (None, None))
-    days_left = (front_exp - today).days
-    rollover_days = _rollover_days()
-
-    # From N days before expiry (inclusive), use next month.
-    should_roll = days_left <= rollover_days and nxt is not None
-    if should_roll:
-        chosen_exp, chosen = next_exp, nxt
-        rolled = True
-    else:
-        chosen_exp, chosen = front_exp, front
-        rolled = False
-
-    return _contract_payload(
-        chosen_exp,
-        chosen,
-        rolled=rolled,
-        rollover_days=rollover_days,
-        front_expiry=front.get("expiry", ""),
-        next_expiry=(nxt.get("expiry") if nxt else None),
-        days_to_front_expiry=days_left,
+    return choose_goldpetal_contract(
+        upcoming,
+        today=today,
+        rollover_days=_rollover_days(),
     )
 
 

--- a/goldpetal/test_position_safety.py
+++ b/goldpetal/test_position_safety.py
@@ -233,6 +233,32 @@ def test_startup_reconcile_restore(monkeypatch_signals=None) -> None:
     del calls
 
 
+def test_s16_overnight_is_closed_not_restored() -> None:
+    import position_safety as ps
+
+    def fake_last(name: str):
+        if name == "S16_HHHL_WICK_1H":
+            return OpenPosition(
+                name, "long", 15400.0, "2026-08-17T22:00:00", "BUY", 15400.0
+            )
+        return None
+
+    orig = ps.last_open_position
+    ps.last_open_position = fake_last  # type: ignore[assignment]
+    try:
+        s16 = _Fake("S16_HHHL_WICK_1H")
+        res = startup_reconcile(
+            {"S16_HHHL_WICK_1H": s16},
+            mode="restore",
+            now=datetime(2026, 8, 18, 9, 5, tzinfo=IST),
+        )
+        assert s16.position == "flat"
+        assert len(res["closes"]) == 1
+        assert res["restored"] == []
+    finally:
+        ps.last_open_position = orig  # type: ignore[assignment]
+
+
 if __name__ == "__main__":
     test_apply_restore_s5()
     print("ok apply")
@@ -254,4 +280,6 @@ if __name__ == "__main__":
     print("ok s4 skip flatten")
     test_startup_reconcile_restore()
     print("ok reconcile")
+    test_s16_overnight_is_closed_not_restored()
+    print("ok s16 overnight close")
     print("ALL test_position_safety OK")

--- a/goldpetal/test_regime_portfolio.py
+++ b/goldpetal/test_regime_portfolio.py
@@ -57,16 +57,20 @@ def test_env_defaults_include_s2(monkeypatch=None) -> None:
     os.environ.pop("ENABLE_S8", None)
     os.environ.pop("ENABLE_S9", None)
     os.environ.pop("ENABLE_S10", None)
+    os.environ.pop("ENABLE_S11", None)
+    os.environ.pop("ENABLE_S13", None)
+    os.environ.pop("ENABLE_S16", None)
     p = portfolio_from_env()
-    assert "S1_NETDELTA" in p.enabled
-    assert "S2_BALANCE" in p.enabled
-    assert "S3_ML" in p.enabled
-    assert "S4_OVERNIGHT" in p.enabled
+    assert "S1_NETDELTA" not in p.enabled
+    assert "S2_BALANCE" not in p.enabled
+    assert "S3_ML" not in p.enabled
+    assert "S4_OVERNIGHT" not in p.enabled
     assert "S5_MINEDGE" in p.enabled
-    assert "S6_MIN30" in p.enabled
-    assert "S8_NET_ZIGZAG" not in p.enabled  # OFF until hist EV confirmed
+    assert "S13_HHHL_DAY" in p.enabled
+    assert "S16_HHHL_WICK_1H" in p.enabled
+    assert "S8_NET_ZIGZAG" in p.enabled
     assert "S9_STATE30" not in p.enabled
-    assert "S10_LEGACY30" in p.enabled  # legacy 30m always ON by default
+    assert "S10_LEGACY30" not in p.enabled
 
     os.environ["ENABLE_S8"] = "true"
     p8 = portfolio_from_env()

--- a/goldpetal/test_strategy_hhhl_day.py
+++ b/goldpetal/test_strategy_hhhl_day.py
@@ -273,6 +273,59 @@ def test_sql_seed_hydrates_today_from_ticks_db() -> None:
         db.unlink()
 
 
+def _front_contract(*, days_left: int, rolled: bool = False, symbol: str = "GOLDPETAL31AUG26FUT") -> dict:
+    return {
+        "symbol": symbol,
+        "token": "1",
+        "rolled": rolled,
+        "rollover_days": 5,
+        "days_to_front_expiry": days_left,
+        "front_month_expiry": "31AUG2026",
+        "next_month_expiry": "30SEP2026",
+    }
+
+
+def test_last_front_session_closes_and_blocks() -> None:
+    s = _fresh("/tmp/s13_roll_last_front.json")
+    s.prev_day = DayOhlc("2026-08-24", 15000, 15100, 14900, 15050)
+    s._day = DayOhlc("2026-08-25", 15080, 15200, 15040, 15180)
+    s.position = "long"
+    s.entry_price = 15180.0
+    s.entry_date = "2026-08-11"
+    s.contract_symbol = "GOLDPETAL31AUG26FUT"
+    s.set_contract(_front_contract(days_left=6, rolled=False))
+    close = s.on_tick(_ts("2026-08-25", "10:00"), 15190)
+    assert close is not None and close.action == "CLOSE"
+    assert s.position == "flat"
+    assert "last front-month" in (close.reason or "")
+    blocked = s.on_tick(_ts("2026-08-25", "23:20"), 15200)
+    assert blocked is None
+    assert s.last_skip == "avoid_front_roll"
+    Path("/tmp/s13_roll_last_front.json").unlink(missing_ok=True)
+
+
+def test_contract_switch_closes_and_resets_book() -> None:
+    s = _fresh("/tmp/s13_roll_switch.json")
+    s.prev_day = DayOhlc("2026-08-25", 15000, 15100, 14900, 15050)
+    s._day = DayOhlc("2026-08-26", 15080, 15200, 15040, 15180)
+    s.position = "long"
+    s.entry_price = 15180.0
+    s.contract_symbol = "GOLDPETAL31AUG26FUT"
+    s.set_contract(
+        _front_contract(
+            days_left=5,
+            rolled=True,
+            symbol="GOLDPETAL30SEP26FUT",
+        )
+    )
+    close = s.on_tick(_ts("2026-08-26", "09:05"), 16010)
+    assert close is not None and close.action == "CLOSE"
+    assert s.position == "flat"
+    assert s.prev_day is None
+    assert s.contract_symbol == "GOLDPETAL30SEP26FUT"
+    Path("/tmp/s13_roll_switch.json").unlink(missing_ok=True)
+
+
 if __name__ == "__main__":
     test_up_close_hh_green_buys_last_15m_holds_next_open()
     print("ok long_last_15m_hold_open")
@@ -298,4 +351,8 @@ if __name__ == "__main__":
     print("ok persist")
     test_sql_seed_hydrates_today_from_ticks_db()
     print("ok sql seed")
+    test_last_front_session_closes_and_blocks()
+    print("ok last front flatten")
+    test_contract_switch_closes_and_resets_book()
+    print("ok contract switch")
     print("ALL test_strategy_hhhl_day OK")

--- a/goldpetal/test_strategy_s16.py
+++ b/goldpetal/test_strategy_s16.py
@@ -123,6 +123,32 @@ def test_on_bar_row_uses_prev() -> None:
     assert s.entry_price == 110.0
 
 
+def test_flatten_at_market_close() -> None:
+    s = _s16()
+    s.on_tick(_t(9, 0), 100.0)
+    s.on_tick(_t(9, 59), 104.0)
+    s.on_tick(_t(10, 0), 100.0)
+    s.on_tick(_t(10, 10), 120.0)
+    s.on_tick(_t(10, 59), 110.0)
+    buy = s.on_tick(_t(11, 0), 110.0)
+    assert buy is not None and buy.action == "BUY"
+    close = s.on_tick(_t(23, 30), 111.0)
+    assert close is not None and close.action == "CLOSE"
+    assert s.position == "flat"
+    assert "session close" in (close.reason or "")
+
+
+def test_overnight_leftover_closes_at_next_open() -> None:
+    s = _s16()
+    s.position = "long"
+    s.entry_price = 110.0
+    s.entry_date = "2026-08-16"
+    close = s.on_tick(_t(9, 0), 112.0)
+    assert close is not None and close.action == "CLOSE"
+    assert s.position == "flat"
+    assert "overnight leftover" in (close.reason or "")
+
+
 if __name__ == "__main__":
     test_forming_hour_does_not_trade()
     test_first_closed_hour_needs_prev()
@@ -131,4 +157,6 @@ if __name__ == "__main__":
     test_down_close_wick_flips()
     test_equal_close_skips()
     test_on_bar_row_uses_prev()
+    test_flatten_at_market_close()
+    test_overnight_leftover_closes_at_next_open()
     print("ALL test_strategy_s16 OK")

--- a/goldpetal/test_symbols.py
+++ b/goldpetal/test_symbols.py
@@ -1,0 +1,102 @@
+"""Gold Petal front vs next month using ROLLOVER_DAYS."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from symbols import choose_goldpetal_contract, s13_roll_intent
+
+
+def _row(symbol: str, token: str, expiry: str) -> dict:
+    return {"symbol": symbol, "token": token, "expiry": expiry, "name": "GOLDPETAL"}
+
+
+def test_choose_stays_front_until_window() -> None:
+    aug = datetime(2026, 8, 31)
+    sep = datetime(2026, 9, 30)
+    rows = [
+        (aug, _row("GOLDPETAL31AUG26FUT", "1", "31AUG2026")),
+        (sep, _row("GOLDPETAL30SEP26FUT", "2", "30SEP2026")),
+    ]
+    c = choose_goldpetal_contract(rows, today=datetime(2026, 8, 24), rollover_days=5)
+    assert c["symbol"] == "GOLDPETAL31AUG26FUT"
+    assert c["rolled"] is False
+    assert c["days_to_front_expiry"] == 7
+
+
+def test_choose_switches_on_rollover_days() -> None:
+    aug = datetime(2026, 8, 31)
+    sep = datetime(2026, 9, 30)
+    rows = [
+        (aug, _row("GOLDPETAL31AUG26FUT", "1", "31AUG2026")),
+        (sep, _row("GOLDPETAL30SEP26FUT", "2", "30SEP2026")),
+    ]
+    c = choose_goldpetal_contract(rows, today=datetime(2026, 8, 26), rollover_days=5)
+    assert c["symbol"] == "GOLDPETAL30SEP26FUT"
+    assert c["rolled"] is True
+    assert c["days_to_front_expiry"] == 5
+
+
+def test_s13_intent_last_front_then_switch() -> None:
+    assert (
+        s13_roll_intent(
+            held_symbol="GOLDPETAL31AUG26FUT",
+            trade_symbol="GOLDPETAL31AUG26FUT",
+            rolled=False,
+            days_to_front_expiry=7,
+            rollover_days=5,
+            in_position=True,
+        )
+        == "trade"
+    )
+    assert (
+        s13_roll_intent(
+            held_symbol="GOLDPETAL31AUG26FUT",
+            trade_symbol="GOLDPETAL31AUG26FUT",
+            rolled=False,
+            days_to_front_expiry=6,
+            rollover_days=5,
+            in_position=True,
+        )
+        == "flatten_last_front"
+    )
+    assert (
+        s13_roll_intent(
+            held_symbol="GOLDPETAL31AUG26FUT",
+            trade_symbol="GOLDPETAL31AUG26FUT",
+            rolled=False,
+            days_to_front_expiry=6,
+            rollover_days=5,
+            in_position=False,
+        )
+        == "block_last_front"
+    )
+    assert (
+        s13_roll_intent(
+            held_symbol="GOLDPETAL31AUG26FUT",
+            trade_symbol="GOLDPETAL30SEP26FUT",
+            rolled=True,
+            days_to_front_expiry=5,
+            rollover_days=5,
+            in_position=True,
+        )
+        == "flatten_switch"
+    )
+    assert (
+        s13_roll_intent(
+            held_symbol="GOLDPETAL30SEP26FUT",
+            trade_symbol="GOLDPETAL30SEP26FUT",
+            rolled=True,
+            days_to_front_expiry=5,
+            rollover_days=5,
+            in_position=True,
+        )
+        == "trade"
+    )
+
+
+if __name__ == "__main__":
+    test_choose_stays_front_until_window()
+    test_choose_switches_on_rollover_days()
+    test_s13_intent_last_front_then_switch()
+    print("ALL test_symbols OK")

--- a/goldpetal/trade_analysis.py
+++ b/goldpetal/trade_analysis.py
@@ -25,10 +25,10 @@ WHAT_IT_GUESSES = {
     "S8_NET_ZIGZAG": "Order-book NET zigzags. Needs a strong rising imbalance (default 14%) and a target that can cover fees.",
     "S11_DISCOVERED": "Auto-discovered rules. They are paper hypotheses, not proven edge.",
     "S12_HHHL30": "30m higher-high / lower-low, last-minute confirm. Skips wick-only fakeouts (close must finish beyond the prior high/low).",
-    "S13_HHHL_DAY": "S16 close-vs-prev on the day candle, last 15m. Holds across days/weeks until the opposite S16 signal. FLIP. Never next-open.",
+    "S13_HHHL_DAY": "S16 close-vs-prev on the day candle, last 15m. Holds the trend across days until the opposite S16 signal or Gold Petal monthly rollover (flatten last front session, then trade next month). FLIP. Never next-open.",
     "S14_WICK30_STRICT": "Same-candle open=high SHORT / open=low LONG, else wick. Weak nearly-equal wicks are skipped (formula order unchanged).",
     "S15_WICK30_NOWICK": "Bald 30m body only, HOLD (no reverse). Fewer trades; still no real edge filter.",
-    "S16_HHHL_WICK_1H": "Wait for the 1h candle to finish. Up close: HH+green LONG / LL+red SHORT. Down close: wick (gap 0). FLIP at that close.",
+    "S16_HHHL_WICK_1H": "Wait for the 1h candle to finish. Up close: HH+green LONG / LL+red SHORT. Down close: wick (gap 0). FLIP at that close. Intraday only: flatten at MARKET_CLOSE, leftover at next open. Never overnight.",
 }
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
S13 is the day-by-day paper book. S4 stays off (Angel/ticks pick was S13).

S13 holds the trend until the opposite daily S16 signal, then the existing Gold Petal rollover rule (`ROLLOVER_DAYS=5`):
- Feed uses next-month futures from 5 calendar days before front expiry
- S13 closes the front-month book on the last front session (does not hold through the switch)
- After the switch it trades the next-month contract as a new trend
- Daily token check reconnects the feed when the contract changes

S16 is the intraday 1h book:
- First fill is the first finished 1h of the session
- Flatten at MARKET_CLOSE (and leftover at next MARKET_OPEN / overnight restore)
- Never overnight

Keep DRY_RUN=true. Not live-unlocked. Not S17.

VM:

```bash
cd ~/goldpetal-repo
git fetch origin cursor/s13-roll-s16-session-a4b2
git checkout cursor/s13-roll-s16-session-a4b2
cd goldpetal
# ENABLE_S13=true  ENABLE_S4=false  ENABLE_S16=true  DRY_RUN=true  ROLLOVER_DAYS=5
pkill -9 -f 'run_strategy|supervise' || true
nohup ./supervise.sh >> data/supervise.log 2>&1 &
```

Look for S13 `hold-until-opposite` + `contract=`, S16 `intraday` + `flatten-at-close`, and `DRY_RUN=true`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e92370bb-ed6a-433d-8b83-fe612227a4b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e92370bb-ed6a-433d-8b83-fe612227a4b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

