### PR TITLE
Put S11 ML pack approvals on the station desk

### DIFF
--- a/goldpetal/analytics/VM_DESK.md
+++ b/goldpetal/analytics/VM_DESK.md
@@ -19,6 +19,39 @@ cannot overwrite start/stop, feed, live picks, DRY_RUN, or capital.
 Keep `DRY_RUN=true` until you intend Angel fills. LIVE_MAX_LOTS cap is 10.
 Paper 100 lots is not live size. Restart the **bot** (type RESTART) after Save strategies / Save money.
 
+## ML / S11 approvals (station 8501)
+
+The **ML** tab on http://127.0.0.1:8501/ is the operator approval desk (what
+Streamlit **Proposals** used to be), plus pack inspector extras:
+
+- Pending cards: paper trades / win / gross / after-tax / Δ vs baseline, env patch, note
+- Loaded pack vs proposed pack (model, family, AUC, thresholds)
+- Packs on disk under `data/discover/packs` — **Load** writes the same paper env
+- Last `weekly_discover.sh` report (`data/discover/latest_report.json`)
+- Approve → paper writes `ENABLE_S11` + `S11_PACK_PATH` and **keeps DRY_RUN=true**
+- Approve → live is blocked here (Unlock live stays on Live money)
+- `safety_ok=false` needs **Accept risk**; S4/S12/S14/S15 cannot be turned on from this tab
+- Type **RESTART** on Engine to load the pack into RAM (desk restart is not enough)
+
+Phone layout `/lite` has a compact pending list. Open `/#ml` for the full inspector.
+
+```bash
+# after Approve → paper, .env looks like:
+ENABLE_S11=true
+S11_PACK_PATH=data/discover/packs/<pack>.json
+DRY_RUN=true
+```
+
+Weekly job (Sunday 19:00 IST):
+
+```bash
+cd ~/goldpetal-repo/goldpetal
+./weekly_discover.sh
+```
+
+Then on the Mac tunnel, Chrome **http://127.0.0.1:8501/** → **ML**.
+Restart the desk after pull: `./scripts/run_desk_vm.sh --restart` (does not restart the bot).
+
 ## Gold Petal chart (Streamlit 8501 — this is the one that opens)
 
 Do **not** use 8787 for the candle chart. Use the desk you already tunnel:
@@ -49,7 +82,7 @@ On the VM desk you can:
 
 - **S14 chart** — Angel/MCX Gold Petal candlesticks (this is the exchange chart)
 - **Overview / Trades / Ticks** — research
-- **Proposals** — Approve → paper (whitelist env). Restart on **8787**. Approve → live is on 8787.
+- **Proposals** — prefer Station **ML** tab on 8501 (`/#ml`). This tab still works if you are on the VM.
 - **Deploy / Ops, Live Deploy, Capital** — read-only snapshots
 - **Control** — stop only (emergency / pause / lock live)
 - **Login** — set `DESK_PASSWORD` (and optional `DESK_TOTP_SECRET` for dangerous actions)

--- a/goldpetal/analytics/app.py
+++ b/goldpetal/analytics/app.py
@@ -96,10 +96,23 @@ PAGES = [
 ]
 
 
-def decide_proposal(pid: str, decision: str, note: str = "", *, apply_env: bool = True) -> dict:
+def decide_proposal(
+    pid: str,
+    decision: str,
+    note: str = "",
+    *,
+    apply_env: bool = True,
+    accept_unsafe: bool = False,
+) -> dict:
     if LOCAL_DESK:
         try:
-            return decide_proposal_local(pid, decision, note=note, apply_env=apply_env)
+            return decide_proposal_local(
+                pid,
+                decision,
+                note=note,
+                apply_env=apply_env,
+                accept_unsafe=accept_unsafe,
+            )
         except Exception as exc:
             return {"ok": False, "error": str(exc)}
     return decide_proposal_remote(pid, decision, note=note)
@@ -541,9 +554,11 @@ def tab_s14_chart(dd: Path) -> None:
 def tab_proposals(dd: Path) -> None:
     st.subheader("Weekend proposals — ML / new & improved strategies")
     st.caption(
-        "Approve → paper **auto-writes** whitelist env keys (e.g. S11_PACK_PATH). "
-        f"Then Restart the bot on the Desk tab ({OPERATOR_URL}). "
-        "Live still needs Unlock live + DRY_RUN=false on Desk."
+        "Prefer the Station **ML** tab at "
+        f"{OPERATOR_URL}#ml — Approve → paper writes whitelist env "
+        "(S11_PACK_PATH + ENABLE_S11) and keeps DRY_RUN=true. "
+        "Then type RESTART on Engine. Approve → live is not on this page "
+        "(Unlock live on the station Live money column)."
     )
     raw = load_json(dd / "control" / "proposals.json")
     items = (raw or {}).get("proposals") if isinstance(raw, dict) else (raw or [])
@@ -579,11 +594,21 @@ def tab_proposals(dd: Path) -> None:
                 key=f"note_{p['id']}",
                 value="",
             )
+            accept_unsafe = True
+            if p.get("safety_ok") is False:
+                accept_unsafe = st.checkbox(
+                    "Accept risk (safety_ok=false)",
+                    key=f"unsafe_{p['id']}",
+                )
             b1, b2, b3 = st.columns(3)
             if b1.button("Approve → paper", key=f"ap_{p['id']}", type="primary"):
-                if p.get("safety_ok") is False:
-                    st.warning("safety_ok=False — only approve if you accept the risk.")
-                res = decide_proposal(p["id"], "approved_paper", note=note, apply_env=True)
+                res = decide_proposal(
+                    p["id"],
+                    "approved_paper",
+                    note=note,
+                    apply_env=True,
+                    accept_unsafe=bool(accept_unsafe),
+                )
                 if res.get("ok"):
                     audit(
                         "approve_paper",

--- a/goldpetal/analytics/local_bridge.py
+++ b/goldpetal/analytics/local_bridge.py
@@ -22,26 +22,17 @@ def decide_proposal_local(
     note: str = "",
     *,
     apply_env: bool = True,
+    accept_unsafe: bool = False,
 ) -> dict[str, Any]:
-    from proposals import decide_proposal
+    from s11_desk import decide_proposal_for_desk
 
-    p = decide_proposal(proposal_id, decision, note=note)
-    env_result = None
-    if apply_env and decision in {"approved_paper", "approved_live"} and p.env_patch:
-        from analytics.env_bridge import apply_env_patch
-
-        env_result = apply_env_patch(p.env_patch)
-    return {
-        "ok": True,
-        "id": p.id,
-        "strategy": p.strategy,
-        "status": p.status,
-        "safety_ok": p.safety_ok,
-        "env_patch": p.env_patch,
-        "env_applied": env_result,
-        "title": p.title,
-        "restart_needed": bool(env_result and env_result.get("ok")),
-    }
+    return decide_proposal_for_desk(
+        proposal_id,
+        decision,
+        note=note,
+        apply_env=apply_env,
+        accept_unsafe=accept_unsafe,
+    )
 
 
 def set_control_local(

--- a/goldpetal/control_panel.py
+++ b/goldpetal/control_panel.py
@@ -60,7 +60,13 @@ from live_readiness import (
 )
 from position_safety import read_bot_health
 from paper_report import summarize_trades
-from proposals import decide_proposal, proposals_snapshot
+from proposals import proposals_snapshot
+from s11_desk import (
+    activate_s11_pack,
+    decide_proposal_for_desk,
+    ml_desk_payload,
+    pack_summary,
+)
 from sheets_pack import sheets_pack_zip_bytes, build_scoreboard_rows, SCORE_FIELDS
 from s14_exchange_sheet import (
     HTML_NAME,
@@ -350,6 +356,15 @@ class ControlHandler(BaseHTTPRequestHandler):
                 status, body, ctype = _json_bytes(proposals_snapshot())
                 self._send(status, body, ctype)
                 return
+            if path == "/api/ml":
+                status, body, ctype = _json_bytes(ml_desk_payload())
+                self._send(status, body, ctype)
+                return
+            if path == "/api/s11/pack":
+                raw = ((qs.get("path") or [""])[0] or "").strip()
+                status, body, ctype = _json_bytes(pack_summary(raw))
+                self._send(status, body, ctype)
+                return
             if path == "/api/capital":
                 status, body, ctype = _json_bytes(capital_snapshot())
                 self._send(status, body, ctype)
@@ -628,8 +643,36 @@ class ControlHandler(BaseHTTPRequestHandler):
                 proposal_id = path[len("/api/proposals/") : -len("/decide")]
                 decision = str(data.get("decision") or "")
                 note = str(data.get("note") or "")
-                prop = decide_proposal(proposal_id, decision, note=note)
-                self._send(*_json_bytes({"ok": True, "proposal": prop.to_dict()}))
+                accept_unsafe = bool(data.get("accept_unsafe"))
+                apply_env = bool(data.get("apply_env", True))
+                try:
+                    res = decide_proposal_for_desk(
+                        proposal_id,
+                        decision,
+                        note=note,
+                        apply_env=apply_env,
+                        accept_unsafe=accept_unsafe,
+                    )
+                except KeyError as exc:
+                    self._send(*_json_bytes({"error": str(exc)}, 404))
+                    return
+                except (ValueError, RuntimeError) as exc:
+                    self._send(*_json_bytes({"error": str(exc)}, 400))
+                    return
+                self._send(*_json_bytes(res, 200 if res.get("ok") else 400))
+                return
+            if path == "/api/s11/activate":
+                pack_path = str(data.get("pack_path") or data.get("path") or "")
+                accept_unsafe = bool(data.get("accept_unsafe"))
+                try:
+                    res = activate_s11_pack(pack_path, accept_unsafe=accept_unsafe)
+                except FileNotFoundError as exc:
+                    self._send(*_json_bytes({"error": str(exc)}, 404))
+                    return
+                except ValueError as exc:
+                    self._send(*_json_bytes({"error": str(exc)}, 400))
+                    return
+                self._send(*_json_bytes(res, 200 if res.get("ok") else 400))
                 return
 
             self._send(*_json_bytes({"error": "not found"}, 404))

--- a/goldpetal/lite.html
+++ b/goldpetal/lite.html
@@ -89,6 +89,14 @@ label.chk { display: flex; gap: .35rem; align-items: center; color: var(--muted)
   </section>
 
   <section class="card">
+    <h2>ML / S11</h2>
+    <p class="hint" id="ml-s11-line">Loading pack…</p>
+    <div id="ml-pending"></div>
+    <p class="hint">Full inspector, pack compare, and discovery report: <a href="/#ml">station ML tab</a>.</p>
+    <p class="flash" id="flash-ml"></p>
+  </section>
+
+  <section class="card">
     <h2>Live money</h2>
     <p class="armed" id="money-line"></p>
     <div class="row" style="margin-top:.5rem">
@@ -113,6 +121,9 @@ const SHORT = {
   S11_DISCOVERED: "S11 pack", S13_HHHL_DAY: "S13 daily S16",
   S16_HHHL_WICK_1H: "S16 HHHL+wick 1h",
 };
+function esc(s) {
+  return String(s ?? "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+}
 function pill(text, kind) {
   return `<span class="pill ${kind || ""}">${text}</span>`;
 }
@@ -168,6 +179,26 @@ function render(d) {
     ? "ARMED — live-picked books send Angel orders."
     : "Paper. Unlock + Live pick + type LIVE + Restart to arm.";
 }
+function renderMl(d) {
+  const s11 = (d && d.s11) || {};
+  const pending = ((d && d.proposals) || {}).pending || [];
+  $("ml-s11-line").textContent = s11.load_hint || (s11.pack_path || "S11_PACK_PATH not set");
+  $("ml-pending").innerHTML = pending.map((p) => {
+    const paper = p.paper || {};
+    return `<div style="border-top:1px solid var(--line);padding:.55rem 0">
+      <div><b>${esc(p.title || p.strategy)}</b></div>
+      <div class="hint">${esc(p.id)} · ${esc(p.strategy)} · safety ${p.safety_ok ? "ok" : "fail"} · trades ${esc(paper.n_trades ?? "—")} · ₹ ${esc(paper.after_tax_pnl_inr ?? "—")}</div>
+      ${p.safety_ok === false ? `<label class="chk"><input type="checkbox" data-unsafe="${esc(p.id)}"/> Accept risk</label>` : ""}
+      <div class="row" style="margin-top:.35rem">
+        <button class="btn ok" type="button" data-ml="approve" data-id="${esc(p.id)}">Approve → paper</button>
+        <button class="btn danger" type="button" data-ml="reject" data-id="${esc(p.id)}">Reject</button>
+      </div>
+    </div>`;
+  }).join("") || `<p class="hint">No pending proposals.</p>`;
+}
+async function loadMl() {
+  renderMl(await api("/api/ml"));
+}
 async function load() {
   render(await api("/api/desk"));
 }
@@ -213,7 +244,23 @@ $("btn-save-cap").onclick = () => act("flash-money", "/api/capital", {
   daily_loss_limit_inr: Number($("cap-dd").value || 0),
 }, "Capital saved");
 load().catch((e) => flash("flash-engine", String(e.message || e), true));
+loadMl().catch((e) => flash("flash-ml", String(e.message || e), true));
+$("ml-pending").addEventListener("click", (ev) => {
+  const btn = ev.target.closest("button[data-ml]");
+  if (!btn) return;
+  const id = btn.dataset.id;
+  const unsafe = document.querySelector(`[data-unsafe="${id}"]`);
+  const decision = btn.dataset.ml === "reject" ? "rejected" : "approved_paper";
+  api("/api/proposals/" + encodeURIComponent(id) + "/decide", {
+    method: "POST",
+    body: JSON.stringify({ decision, accept_unsafe: !!(unsafe && unsafe.checked) }),
+  }).then((res) => {
+    flash("flash-ml", res.reminder || res.note || "ok");
+    return loadMl();
+  }).catch((e) => flash("flash-ml", String(e.message || e), true));
+});
 setInterval(() => { if (!typing()) load().catch(() => {}); }, 6000);
+setInterval(() => { if (!typing()) loadMl().catch(() => {}); }, 15000);
 </script>
 </body>
 </html>

--- a/goldpetal/operator_desk.py
+++ b/goldpetal/operator_desk.py
@@ -8,7 +8,7 @@ OPERATOR_PANEL = "8501"
 OPERATOR_URL = "http://127.0.0.1:8501/"
 OPERATOR_WRITES = (
     "Emergency & trading, start/stop/feed, ENABLE_*, DRY_RUN, LIVE_MAX_LOTS, "
-    "live_approved, Restart bot, Capital — HTML desk on 8501"
+    "live_approved, S11 ML pack approve, Restart bot, Capital — HTML desk on 8501"
 )
 
 

--- a/goldpetal/s11_desk.py
+++ b/goldpetal/s11_desk.py
@@ -1,0 +1,523 @@
+"""S11 ML pack inspector + paper-safe proposal apply for the HTML desk.
+
+Streamlit used to approve weekend packs (S11_PACK_PATH + ENABLE_S11). The
+station on 8501 now owns that flow: inspect packs, compare the loaded pack
+to a proposal, write whitelist .env keys, and never live-unlock.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from proposals import decide_proposal, get_proposal, proposals_snapshot
+from position_safety import read_bot_health
+
+IST = ZoneInfo("Asia/Kolkata")
+ROOT = Path(__file__).resolve().parent
+
+LIVE_BLOCKED_REASON = (
+    "Live approval is not on the ML tab. Approve → paper first, then Unlock live "
+    "on Live money after the pack looks good. This tab never sets DRY_RUN=false."
+)
+
+# Paper books that weekly ML must not turn back on.
+RETIRED_ENABLE_TRUE: dict[str, str] = {
+    "ENABLE_S4": "S4 stays off (research). Paper daily swing is S13.",
+    "ENABLE_S12": "S12 is retired from paper.",
+    "ENABLE_S14": "S14 is retired from paper.",
+    "ENABLE_S15": "S15 is retired from paper.",
+}
+
+DROP_KEYS = frozenset({"LIVE_UNLOCK", "LIVE_UNLOCKED", "LIVE_APPROVED"})
+
+
+def _now_iso() -> str:
+    return datetime.now(IST).isoformat(timespec="seconds")
+
+
+def _mtime_ist(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return datetime.fromtimestamp(path.stat().st_mtime, IST).isoformat(timespec="seconds")
+
+
+def _tail_file(path: Path, n: int = 12) -> str:
+    if not path.exists():
+        return ""
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as fh:
+            fh.seek(max(0, size - 65536))
+            data = fh.read().decode("utf-8", errors="replace")
+        return "\n".join(data.splitlines()[-n:])
+    except OSError:
+        return ""
+
+
+def data_root(root: Path = ROOT) -> Path:
+    return (root / "data").resolve()
+
+
+def resolve_data_path(raw: str, *, root: Path = ROOT) -> Path:
+    """Resolve a pack/model path. Must sit under <root>/data (no .. / ~)."""
+    value = str(raw or "").strip().replace("\\", "/")
+    if not value:
+        raise ValueError("path is empty")
+    if ".." in value or value.startswith("~"):
+        raise ValueError("path must not contain .. or ~")
+    p = Path(value)
+    base = data_root(root)
+    if p.is_absolute():
+        resolved = p.resolve()
+    else:
+        if not value.startswith("data/"):
+            raise ValueError("path must start with data/ or be under data/")
+        resolved = (root / value).resolve()
+    try:
+        resolved.relative_to(base)
+    except ValueError as exc:
+        raise ValueError("path must be under data/") from exc
+    return resolved
+
+
+def to_env_pack_path(path: Path, *, root: Path = ROOT) -> str:
+    rel = path.resolve().relative_to(data_root(root))
+    return f"data/{rel.as_posix()}"
+
+
+def normalize_pack_key(raw: str, *, root: Path = ROOT) -> str:
+    value = str(raw or "").strip()
+    if not value:
+        return ""
+    try:
+        return to_env_pack_path(resolve_data_path(value, root=root), root=root)
+    except (ValueError, OSError):
+        return value.replace("\\", "/")
+
+
+def paper_safe_env_patch(
+    patch: dict[str, Any] | None,
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Force DRY_RUN=true. Drop live-unlock and retired ENABLE_*=true keys."""
+    skipped: dict[str, str] = {}
+    clean: dict[str, str] = {}
+    for key_raw, raw in (patch or {}).items():
+        key = str(key_raw).strip()
+        val = str(raw).strip()
+        if not key:
+            continue
+        if key == "DRY_RUN":
+            if val.lower() not in {"true", "1", "yes", "y"}:
+                skipped[key] = "ML tab keeps DRY_RUN=true"
+            continue
+        if key in DROP_KEYS:
+            skipped[key] = "live unlock is not allowed from ML"
+            continue
+        if key in RETIRED_ENABLE_TRUE and val.lower() in {"true", "1", "yes", "y"}:
+            skipped[key] = RETIRED_ENABLE_TRUE[key]
+            continue
+        clean[key] = val
+    clean["DRY_RUN"] = "true"
+    return clean, skipped
+
+
+def apply_paper_env_patch(
+    patch: dict[str, Any] | None,
+    *,
+    env_path: Path | None = None,
+) -> dict[str, Any]:
+    from analytics.env_bridge import apply_env_patch
+
+    clean, skipped = paper_safe_env_patch(patch)
+    result = apply_env_patch(clean, path=env_path)
+    merged_skip = dict(skipped)
+    merged_skip.update(result.get("skipped") or {})
+    out = dict(result)
+    out["skipped"] = merged_skip
+    out["paper_safe"] = True
+    out["forced_dry_run"] = True
+    return out
+
+
+def pack_summary(raw: str | Path | None, *, root: Path = ROOT) -> dict[str, Any]:
+    """Read a discovery pack JSON without loading the joblib model."""
+    value = str(raw or "").strip()
+    if not value:
+        return {
+            "path": "",
+            "exists": False,
+            "error": "empty",
+        }
+    try:
+        path = resolve_data_path(value, root=root) if not isinstance(raw, Path) else raw
+        if isinstance(raw, Path):
+            try:
+                path.relative_to(data_root(root))
+            except ValueError:
+                path = resolve_data_path(str(raw), root=root)
+    except ValueError as exc:
+        return {"path": value, "exists": False, "error": str(exc)}
+
+    env_path = ""
+    try:
+        env_path = to_env_pack_path(path, root=root)
+    except ValueError:
+        env_path = str(path)
+
+    if not path.is_file():
+        return {
+            "path": env_path or value,
+            "exists": False,
+            "error": "missing",
+        }
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        return {
+            "path": env_path,
+            "exists": True,
+            "error": f"read failed: {exc}",
+        }
+    if not isinstance(data, dict):
+        return {"path": env_path, "exists": True, "error": "pack is not an object"}
+
+    features = list(data.get("features") or [])
+    paper = data.get("paper") if isinstance(data.get("paper"), dict) else {}
+    model_raw = str(data.get("model_path") or "")
+    model_exists = False
+    if model_raw:
+        try:
+            model_exists = resolve_data_path(model_raw, root=root).is_file()
+        except ValueError:
+            model_exists = Path(model_raw).is_file()
+
+    safety_reasons = list(data.get("safety_reasons") or [])
+    return {
+        "path": env_path,
+        "exists": True,
+        "error": "",
+        "id": str(data.get("id") or path.stem),
+        "week_id": str(data.get("week_id") or ""),
+        "strategy": str(data.get("strategy") or "S11_DISCOVERED"),
+        "model_name": str(data.get("model_name") or ""),
+        "model_path": model_raw,
+        "model_exists": model_exists,
+        "family": str(data.get("family") or ""),
+        "rationale": str(data.get("rationale") or ""),
+        "auc": data.get("auc"),
+        "buy_prob": data.get("buy_prob"),
+        "short_prob": data.get("short_prob"),
+        "min_hold_sec": data.get("min_hold_sec"),
+        "every_n_ticks": data.get("every_n_ticks"),
+        "min_imb": data.get("min_imb"),
+        "safety_ok": bool(data.get("safety_ok", False)),
+        "safety_reasons": safety_reasons[:12],
+        "n_features": len(features),
+        "features_head": features[:12],
+        "paper": {
+            "n_trades": paper.get("n_trades"),
+            "win_rate": paper.get("win_rate"),
+            "gross_pnl": paper.get("gross_pnl"),
+            "after_tax_pnl": paper.get("after_tax_pnl"),
+        },
+        "behavior_summary": str(data.get("behavior_summary") or "")[:400],
+        "created_at_ist": str(data.get("created_at_ist") or ""),
+        "mtime_ist": _mtime_ist(path),
+        "bytes": path.stat().st_size,
+    }
+
+
+def list_s11_packs(*, root: Path = ROOT, limit: int = 24) -> list[dict[str, Any]]:
+    packs_dir = root / "data" / "discover" / "packs"
+    if not packs_dir.is_dir():
+        return []
+    files = sorted(
+        (p for p in packs_dir.glob("*.json") if p.is_file()),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    out: list[dict[str, Any]] = []
+    for path in files[: max(1, int(limit))]:
+        row = pack_summary(path, root=root)
+        out.append(row)
+    return out
+
+
+def s11_status(*, root: Path = ROOT, env_path: Path | None = None) -> dict[str, Any]:
+    from analytics.env_bridge import read_env
+
+    env_file = env_path or (root / ".env")
+    env = read_env(env_file)
+    pack_raw = str(env.get("S11_PACK_PATH") or "").strip()
+    enable_raw = str(env.get("ENABLE_S11") or "").strip().lower()
+    enable = enable_raw in {"1", "true", "yes", "y"}
+    dry_raw = str(env.get("DRY_RUN", "true")).strip().lower()
+    dry_run = dry_raw in {"1", "true", "yes", "y", ""}
+    pack = pack_summary(pack_raw, root=root) if pack_raw else pack_summary("", root=root)
+    hint = "ready"
+    if not pack_raw:
+        hint = "S11_PACK_PATH not set — S11 loads disabled"
+    elif not pack.get("exists"):
+        hint = f"pack missing: {pack.get('path') or pack_raw}"
+    elif pack.get("error"):
+        hint = str(pack.get("error"))
+    elif not pack.get("model_exists"):
+        hint = "pack JSON ok but joblib model file is missing"
+    elif not enable:
+        hint = "pack on disk, ENABLE_S11 is false"
+    else:
+        hint = "ENABLE_S11 + pack set — type RESTART if the bot still shows pack not set"
+    health = read_bot_health()
+    positions = health.get("positions") if isinstance(health, dict) else {}
+    s11_pos = None
+    if isinstance(positions, dict):
+        s11_pos = positions.get("S11_DISCOVERED") or positions.get("S11")
+    return {
+        "enable_s11": enable,
+        "pack_path": pack_raw,
+        "pack_key": normalize_pack_key(pack_raw, root=root),
+        "pack": pack,
+        "dry_run": dry_run,
+        "load_hint": hint,
+        "bot_health_ts": (health or {}).get("ts_ist") if isinstance(health, dict) else "",
+        "s11_position": s11_pos,
+    }
+
+
+def discover_status(*, root: Path = ROOT) -> dict[str, Any]:
+    discover = root / "data" / "discover"
+    report_path = discover / "latest_report.json"
+    cron_path = discover / "cron.log"
+    candidates: list[dict[str, Any]] = []
+    summary = ""
+    week_id = ""
+    if report_path.is_file():
+        try:
+            raw = json.loads(report_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            raw = {}
+        if isinstance(raw, dict):
+            summary = str(raw.get("behavior_summary") or raw.get("summary") or "")[:500]
+            week_id = str(raw.get("week_id") or "")
+            rows = raw.get("candidates") or []
+            if isinstance(rows, list):
+                for row in rows[:8]:
+                    if not isinstance(row, dict):
+                        continue
+                    pack_path = str(row.get("pack_path") or "")
+                    item = {
+                        "model": row.get("model") or row.get("model_name"),
+                        "template": row.get("template"),
+                        "family": row.get("family"),
+                        "auc": row.get("auc"),
+                        "n_trades": row.get("n_trades"),
+                        "win_rate": row.get("win_rate"),
+                        "gross_pnl": row.get("gross_pnl"),
+                        "after_tax_pnl": row.get("after_tax_pnl"),
+                        "safety_ok": row.get("safety_ok"),
+                        "pack_path": pack_path,
+                    }
+                    if pack_path:
+                        item["pack"] = pack_summary(pack_path, root=root)
+                    candidates.append(item)
+    return {
+        "report_path": str(report_path.relative_to(root)) if report_path.exists() else "",
+        "report_mtime_ist": _mtime_ist(report_path),
+        "week_id": week_id,
+        "behavior_summary": summary,
+        "candidates": candidates,
+        "cron_tail": _tail_file(cron_path, 10),
+        "packs_dir": "data/discover/packs",
+    }
+
+
+def _annotate_proposal(
+    row: dict[str, Any],
+    *,
+    loaded_key: str,
+    root: Path,
+) -> dict[str, Any]:
+    out = dict(row)
+    paper = out.get("paper") if isinstance(out.get("paper"), dict) else {}
+    extra = paper.get("extra") if isinstance(paper.get("extra"), dict) else {}
+    patch = out.get("env_patch") if isinstance(out.get("env_patch"), dict) else {}
+    pack_raw = str(patch.get("S11_PACK_PATH") or out.get("model_path") or "").strip()
+    proposed = pack_summary(pack_raw, root=root) if pack_raw else pack_summary("", root=root)
+    proposed_key = str(proposed.get("path") or "")
+    out["proposed_pack"] = proposed
+    out["same_as_loaded"] = bool(loaded_key and proposed_key and loaded_key == proposed_key)
+    out["would_disable_s11"] = str(patch.get("ENABLE_S11") or "").strip().lower() in {
+        "false",
+        "0",
+        "no",
+        "n",
+    }
+    out["extra"] = extra
+    return out
+
+
+def ml_desk_payload(
+    *,
+    root: Path = ROOT,
+    env_path: Path | None = None,
+    proposals_path: Path | None = None,
+) -> dict[str, Any]:
+    s11 = s11_status(root=root, env_path=env_path)
+    loaded_key = str(s11.get("pack_key") or "")
+    snap = (
+        proposals_snapshot(path=proposals_path)
+        if proposals_path is not None
+        else proposals_snapshot()
+    )
+    pending = [
+        _annotate_proposal(p, loaded_key=loaded_key, root=root)
+        for p in (snap.get("pending") or [])
+    ]
+    decided = [
+        _annotate_proposal(p, loaded_key=loaded_key, root=root)
+        for p in (snap.get("decided") or [])
+    ]
+    snap = dict(snap)
+    snap["pending"] = pending
+    snap["decided"] = decided
+    packs = list_s11_packs(root=root)
+    for row in packs:
+        row["is_loaded"] = bool(loaded_key and row.get("path") == loaded_key)
+    return {
+        "ok": True,
+        "ts_ist": _now_iso(),
+        "proposals": snap,
+        "s11": s11,
+        "packs": packs,
+        "discover": discover_status(root=root),
+        "live_blocked": True,
+        "live_blocked_reason": LIVE_BLOCKED_REASON,
+        "note": (
+            "Approve → paper writes whitelist .env (S11_PACK_PATH + ENABLE_S11) and "
+            "keeps DRY_RUN=true. Type RESTART on Engine to load the pack into RAM. "
+            "Live stays on Live money — this tab never arms Angel."
+        ),
+    }
+
+
+def decide_proposal_for_desk(
+    proposal_id: str,
+    decision: str,
+    note: str = "",
+    *,
+    apply_env: bool = True,
+    accept_unsafe: bool = False,
+    proposals_path: Path | None = None,
+    state_path: Path | None = None,
+    env_path: Path | None = None,
+    root: Path = ROOT,
+) -> dict[str, Any]:
+    """Approve → paper / reject from the station. Never approved_live."""
+    if decision == "approved_live":
+        return {
+            "ok": False,
+            "error": LIVE_BLOCKED_REASON,
+            "live_blocked": True,
+        }
+    kwargs: dict[str, Any] = {}
+    if proposals_path is not None:
+        kwargs["path"] = proposals_path
+    if state_path is not None:
+        kwargs["state_path"] = state_path
+    found = get_proposal(proposal_id, path=proposals_path) if proposals_path else get_proposal(
+        proposal_id
+    )
+    if found is None:
+        raise KeyError(f"proposal not found: {proposal_id}")
+    if decision == "approved_paper" and found.safety_ok is False and not accept_unsafe:
+        return {
+            "ok": False,
+            "error": (
+                "safety_ok=False — tick Accept risk to approve this pack into paper. "
+                "Unsafe S11 proposals usually write ENABLE_S11=false."
+            ),
+            "safety_ok": False,
+            "proposal": found.to_dict(),
+        }
+    p = decide_proposal(proposal_id, decision, note=note, **kwargs)
+    env_result = None
+    if apply_env and decision == "approved_paper" and p.env_patch:
+        env_result = apply_paper_env_patch(p.env_patch, env_path=env_path)
+    restart_needed = bool(env_result and env_result.get("ok"))
+    reminder = ""
+    if env_result and not env_result.get("ok"):
+        reminder = (
+            "Approved in the book, but .env write failed: "
+            + str(env_result.get("error") or "unknown")
+        )
+    elif restart_needed:
+        reminder = "Type RESTART on Engine to load the pack into RAM. Desk restart is not enough."
+    skipped = (env_result or {}).get("skipped") or {}
+    if skipped:
+        bits = ", ".join(f"{k} ({v})" for k, v in skipped.items())
+        reminder = (reminder + " Skipped " + bits).strip()
+    return {
+        "ok": True,
+        "id": p.id,
+        "strategy": p.strategy,
+        "status": p.status,
+        "safety_ok": p.safety_ok,
+        "env_patch": p.env_patch,
+        "env_applied": env_result,
+        "title": p.title,
+        "proposal": p.to_dict(),
+        "restart_needed": restart_needed,
+        "reminder": reminder,
+        "ml": ml_desk_payload(root=root, env_path=env_path, proposals_path=proposals_path),
+    }
+
+
+def activate_s11_pack(
+    pack_path: str,
+    *,
+    accept_unsafe: bool = False,
+    env_path: Path | None = None,
+    root: Path = ROOT,
+) -> dict[str, Any]:
+    """Load a pack from disk into paper .env without a proposal row."""
+    path = resolve_data_path(pack_path, root=root)
+    if not path.is_file():
+        raise FileNotFoundError(f"pack missing: {to_env_pack_path(path, root=root)}")
+    packs_dir = (root / "data" / "discover" / "packs").resolve()
+    try:
+        path.resolve().relative_to(packs_dir)
+    except ValueError as exc:
+        raise ValueError("pack must be under data/discover/packs/") from exc
+    summary = pack_summary(path, root=root)
+    if summary.get("safety_ok") is False and not accept_unsafe:
+        return {
+            "ok": False,
+            "error": "pack safety_ok=False — tick Accept risk to load it into paper.",
+            "pack": summary,
+        }
+    env_key = to_env_pack_path(path, root=root)
+    env_result = apply_paper_env_patch(
+        {
+            "ENABLE_S11": "true",
+            "S11_PACK_PATH": env_key,
+            "DRY_RUN": "true",
+        },
+        env_path=env_path,
+    )
+    return {
+        "ok": bool(env_result.get("ok")),
+        "pack_path": env_key,
+        "pack": summary,
+        "env_applied": env_result,
+        "restart_needed": bool(env_result.get("ok")),
+        "reminder": (
+            "Type RESTART on Engine to load the pack into RAM. Desk restart is not enough."
+            if env_result.get("ok")
+            else ""
+        ),
+        "s11": s11_status(root=root, env_path=env_path),
+    }

--- a/goldpetal/s11_desk.py
+++ b/goldpetal/s11_desk.py
@@ -143,6 +143,35 @@ def apply_paper_env_patch(
     return out
 
 
+def _read_json_object(path: Path) -> tuple[dict[str, Any] | None, str]:
+    """Load a JSON object. Never raise on joblib/pickle (starts with 0x80)."""
+    try:
+        with path.open("rb") as fh:
+            head = fh.read(8)
+            if head.startswith(b"\x80"):
+                return None, "binary pickle/joblib, not pack JSON"
+            blob = head + fh.read()
+        text = blob.decode("utf-8")
+        data = json.loads(text)
+    except UnicodeDecodeError:
+        return None, "not utf-8 (binary file)"
+    except (json.JSONDecodeError, OSError) as exc:
+        return None, f"read failed: {exc}"
+    if not isinstance(data, dict):
+        return None, "pack is not an object"
+    return data, ""
+
+
+def _json_pack_path(raw: str) -> str:
+    """Prefer a .json pack path; skip joblib model_path fallbacks."""
+    value = str(raw or "").strip()
+    if not value:
+        return ""
+    if value.lower().endswith((".joblib", ".pkl", ".pickle", ".bin")):
+        return ""
+    return value
+
+
 def pack_summary(raw: str | Path | None, *, root: Path = ROOT) -> dict[str, Any]:
     """Read a discovery pack JSON without loading the joblib model."""
     value = str(raw or "").strip()
@@ -174,13 +203,20 @@ def pack_summary(raw: str | Path | None, *, root: Path = ROOT) -> dict[str, Any]
             "exists": False,
             "error": "missing",
         }
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
+    if path.suffix.lower() in {".joblib", ".pkl", ".pickle", ".bin"}:
         return {
             "path": env_path,
             "exists": True,
-            "error": f"read failed: {exc}",
+            "error": "model file, not pack JSON",
+            "model_path": env_path,
+            "model_exists": True,
+        }
+    data, err = _read_json_object(path)
+    if err:
+        return {
+            "path": env_path,
+            "exists": True,
+            "error": err,
         }
     if not isinstance(data, dict):
         return {"path": env_path, "exists": True, "error": "pack is not an object"}
@@ -296,10 +332,10 @@ def discover_status(*, root: Path = ROOT) -> dict[str, Any]:
     summary = ""
     week_id = ""
     if report_path.is_file():
-        try:
-            raw = json.loads(report_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            raw = {}
+        raw_obj, err = _read_json_object(report_path)
+        raw = raw_obj or {}
+        if err and not raw:
+            summary = err
         if isinstance(raw, dict):
             summary = str(raw.get("behavior_summary") or raw.get("summary") or "")[:500]
             week_id = str(raw.get("week_id") or "")
@@ -308,7 +344,7 @@ def discover_status(*, root: Path = ROOT) -> dict[str, Any]:
                 for row in rows[:8]:
                     if not isinstance(row, dict):
                         continue
-                    pack_path = str(row.get("pack_path") or "")
+                    pack_path = _json_pack_path(str(row.get("pack_path") or ""))
                     item = {
                         "model": row.get("model") or row.get("model_name"),
                         "template": row.get("template"),
@@ -345,7 +381,10 @@ def _annotate_proposal(
     paper = out.get("paper") if isinstance(out.get("paper"), dict) else {}
     extra = paper.get("extra") if isinstance(paper.get("extra"), dict) else {}
     patch = out.get("env_patch") if isinstance(out.get("env_patch"), dict) else {}
-    pack_raw = str(patch.get("S11_PACK_PATH") or out.get("model_path") or "").strip()
+    pack_raw = _json_pack_path(
+        str(patch.get("S11_PACK_PATH") or "").strip()
+        or str(out.get("model_path") or "").strip()
+    )
     proposed = pack_summary(pack_raw, root=root) if pack_raw else pack_summary("", root=root)
     proposed_key = str(proposed.get("path") or "")
     out["proposed_pack"] = proposed
@@ -366,13 +405,32 @@ def ml_desk_payload(
     env_path: Path | None = None,
     proposals_path: Path | None = None,
 ) -> dict[str, Any]:
-    s11 = s11_status(root=root, env_path=env_path)
+    try:
+        s11 = s11_status(root=root, env_path=env_path)
+    except Exception as exc:
+        s11 = {
+            "enable_s11": False,
+            "pack_path": "",
+            "pack_key": "",
+            "pack": {"exists": False, "error": str(exc)},
+            "dry_run": True,
+            "load_hint": f"status failed: {exc}",
+            "bot_health_ts": "",
+            "s11_position": None,
+        }
     loaded_key = str(s11.get("pack_key") or "")
-    snap = (
-        proposals_snapshot(path=proposals_path)
-        if proposals_path is not None
-        else proposals_snapshot()
-    )
+    try:
+        snap = (
+            proposals_snapshot(path=proposals_path)
+            if proposals_path is not None
+            else proposals_snapshot()
+        )
+    except Exception:
+        snap = {
+            "pending": [],
+            "decided": [],
+            "counts": {"pending": 0, "total": 0},
+        }
     pending = [
         _annotate_proposal(p, loaded_key=loaded_key, root=root)
         for p in (snap.get("pending") or [])
@@ -384,7 +442,10 @@ def ml_desk_payload(
     snap = dict(snap)
     snap["pending"] = pending
     snap["decided"] = decided
-    packs = list_s11_packs(root=root)
+    try:
+        packs = list_s11_packs(root=root)
+    except Exception:
+        packs = []
     for row in packs:
         row["is_loaded"] = bool(loaded_key and row.get("path") == loaded_key)
     return {

--- a/goldpetal/station.html
+++ b/goldpetal/station.html
@@ -56,8 +56,6 @@ button, input, select { font: inherit; }
   border-right: 1px solid var(--line); background: var(--panel); }
 .col:last-child { border-right: 0; }
 .pane { padding: .7rem .85rem; border-bottom: 1px solid var(--line); }
-.pane h2, #dl-panel h2 { margin: 0 0 .45rem; font: 600 12px/1.2 var(--serif); letter-spacing: .12em;
-  text-transform: uppercase; color: var(--gold); }
 .grow { flex: 1; min-height: 0; display: flex; flex-direction: column; }
 .scroll { overflow: auto; flex: 1; min-height: 0; }
 .row { display: flex; flex-wrap: wrap; gap: .4rem; align-items: center; }
@@ -86,8 +84,32 @@ input[type=number], input[type=text], input[type=date], select {
   padding: .38rem .5rem; font: 13px var(--mono); }
 input[type=number], input[type=text] { width: 6.4rem; }
 input[type=date] { width: 11.2rem; }
-#dl-panel { padding: .85rem 1rem 1.1rem; }
-#dl-panel[hidden], #grid-wrap[hidden] { display: none !important; }
+#dl-panel, #ml-panel { padding: .85rem 1rem 1.1rem; }
+#dl-panel[hidden], #ml-panel[hidden], #grid-wrap[hidden] { display: none !important; }
+.pane h2, #dl-panel h2, #ml-panel h2 { margin: 0 0 .45rem; font: 600 12px/1.2 var(--serif); letter-spacing: .12em;
+  text-transform: uppercase; color: var(--gold); }
+textarea { background: #fff; color: var(--text); border: 1px solid var(--line); border-radius: 6px;
+  padding: .4rem .5rem; font: 13px var(--font); width: 100%; min-height: 2.5rem; resize: vertical; }
+.ml-banner { margin: 0 0 .7rem; padding: .55rem .7rem; border: 1px solid #ead3a8; border-radius: 8px;
+  background: #fbf8f1; color: var(--warn); font: 600 13px/1.4 var(--font); }
+.ml-banner.ok { border-color: #b7dcc8; background: #f4faf6; color: var(--ok); }
+.ml-card { border: 1px solid var(--line); border-radius: 10px; background: #fff;
+  padding: .75rem .85rem; margin: 0 0 .7rem; box-shadow: 0 8px 18px rgba(48, 36, 12, .04); }
+.ml-card h3 { margin: 0 0 .28rem; font: 600 16px/1.3 var(--serif); }
+.ml-meta { font: 12px/1.45 var(--mono); color: var(--muted); }
+.ml-stats { display: grid; grid-template-columns: repeat(5, minmax(0,1fr)); gap: .4rem; margin: .55rem 0; }
+.ml-stat { background: var(--head); border: 1px solid var(--line); border-radius: 8px; padding: .4rem .5rem; }
+.ml-stat b { display: block; font: 600 10px/1 var(--font); letter-spacing: .1em; text-transform: uppercase; color: var(--muted); }
+.ml-stat span { font: 600 14px/1.45 var(--mono); font-variant-numeric: tabular-nums; }
+.ml-compare { display: grid; grid-template-columns: 1fr 1fr; gap: .55rem; margin: .45rem 0 .2rem; }
+.ml-box { border: 1px dashed var(--line); border-radius: 8px; padding: .45rem .55rem; background: var(--head); }
+.ml-box b { display: block; font: 600 10px/1 var(--font); letter-spacing: .1em; text-transform: uppercase; color: var(--muted); margin-bottom: .2rem; }
+pre.env { margin: .4rem 0 0; padding: .45rem .55rem; background: var(--head); border: 1px solid var(--line);
+  border-radius: 8px; font: 11px/1.4 var(--mono); overflow: auto; max-height: 8rem; white-space: pre-wrap; }
+#ml-badge { font: 600 11px/1 var(--mono); color: var(--gold); margin-left: .15rem; }
+@media (max-width: 900px) {
+  .ml-stats, .ml-compare { grid-template-columns: 1fr 1fr; }
+}
 label.chk { display: flex; gap: .35rem; align-items: center; color: var(--muted); font-size: 13px; }
 .flash { min-height: 1rem; color: var(--gold); font-size: 13px; margin: .3rem 0 0; }
 .flash.bad { color: var(--bad); }
@@ -171,6 +193,7 @@ label.chk { display: flex; gap: .35rem; align-items: center; color: var(--muted)
           <button class="tab" type="button" data-tab="signals">Signals</button>
           <button class="tab" type="button" data-tab="score">P&amp;L</button>
           <button class="tab" type="button" data-tab="why">Edge</button>
+          <button class="tab" type="button" data-tab="ml">ML<span id="ml-badge"></span></button>
           <button class="tab" type="button" data-tab="dl">Downloads</button>
         </div>
         <select id="hist-strat"><option value="">All books</option></select>
@@ -202,6 +225,32 @@ label.chk { display: flex; gap: .35rem; align-items: center; color: var(--muted)
           <button class="btn" type="button" id="btn-s14-zip">Download S14 sheet ZIP</button>
         </div>
         <p class="flash" id="flash-dl"></p>
+      </div>
+      <div class="scroll" id="ml-panel" hidden>
+        <h2>ML approvals — S11 packs</h2>
+        <p class="hint">Weekend discovery writes a proposal. Approve → paper writes <span class="mono">S11_PACK_PATH</span> + <span class="mono">ENABLE_S11</span> and keeps <span class="mono">DRY_RUN=true</span>. Type RESTART on Engine to load RAM. Live stays on Live money — this tab never arms Angel.</p>
+        <div class="ml-banner" id="ml-restart" hidden>Type RESTART on Engine to load the pack into RAM. Desk restart is not enough.</div>
+        <p class="flash" id="flash-ml"></p>
+        <div class="row" style="margin-top:.45rem">
+          <select id="ml-filter">
+            <option value="">All proposals</option>
+            <option value="S11_DISCOVERED">S11 pack</option>
+            <option value="S8_NET_ZIGZAG">S8 zigzag</option>
+            <option value="S5_MINEDGE">S5 minedge</option>
+            <option value="S4_OVERNIGHT">S4 (research)</option>
+          </select>
+          <button class="btn" type="button" id="btn-ml-refresh">Refresh</button>
+        </div>
+        <div id="ml-loaded"></div>
+        <h2 style="margin-top:1rem">Pending</h2>
+        <div id="ml-pending"></div>
+        <h2 style="margin-top:1rem">Packs on disk</h2>
+        <p class="hint">Newest first under <span class="mono">data/discover/packs</span>. Load writes the same paper env as Approve → paper.</p>
+        <div id="ml-packs"></div>
+        <h2 style="margin-top:1rem">Last discovery</h2>
+        <div id="ml-discover"></div>
+        <h2 style="margin-top:1rem">Recent decisions</h2>
+        <div id="ml-decided"></div>
       </div>
       <div class="pane">
         <p class="mono" id="grid-meta">loading market…</p>
@@ -270,7 +319,7 @@ label.chk { display: flex; gap: .35rem; align-items: center; color: var(--muted)
     <div id="foot-left">station · 8501</div>
     <div id="foot-ml">learner …</div>
     <div>
-      Downloads tab · <a href="/lite">phone layout</a>
+      ML tab · Downloads · <a href="/lite">phone layout</a>
       · <a href="/full">old archive</a>
     </div>
   </footer>
@@ -293,6 +342,8 @@ let lastDesk = {};
 let lastTape = { ticks: [], signals: [], live_orders: [], tick_count: 0, ltp: null };
 let lastHist = { trades: [], open: [], scoreboard: [], total_open: 0, total_closed: 0 };
 let lastWhy = null;
+let lastMl = null;
+let mlRestartNeeded = false;
 
 function esc(s) {
   return String(s ?? "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
@@ -403,12 +454,39 @@ function renderKpis() {
   pnlEl.className = pnlClass(pnl);
   $("kpi-wr").textContent = wr == null || wr === "" ? "—" : pct(wr);
 }
+function wrFrac(n) {
+  const x = Number(n);
+  if (n == null || n === "" || !Number.isFinite(x)) return "—";
+  if (Math.abs(x) <= 1.5) return (x * 100).toFixed(0) + "%";
+  return x.toFixed(0) + "%";
+}
+function aucStr(n) {
+  const x = Number(n);
+  if (!Number.isFinite(x)) return "—";
+  return x.toFixed(3);
+}
+function packLine(p) {
+  if (!p || !(p.path || p.id)) return "no pack";
+  if (p.exists === false) return esc(p.path || "") + " (missing)";
+  const bits = [
+    p.model_name || p.id,
+    p.family,
+    p.auc != null ? "AUC " + aucStr(p.auc) : "",
+    p.safety_ok ? "safety ok" : (p.safety_ok === false ? "safety fail" : ""),
+  ].filter(Boolean);
+  return bits.join(" · ");
+}
+function mlStat(label, value, cls) {
+  return `<div class="ml-stat"><b>${esc(label)}</b><span class="${cls || ""}">${value}</span></div>`;
+}
 function showMainTab() {
-  const dl = watchTab === "dl";
-  $("grid-wrap").hidden = dl;
-  $("dl-panel").hidden = !dl;
-  $("hist-strat").style.visibility = dl ? "hidden" : "visible";
-  if (dl) $("grid-meta").textContent = "CSV / ZIP / Sheets — pick From and To (IST)";
+  const extra = watchTab === "dl" || watchTab === "ml";
+  $("grid-wrap").hidden = extra;
+  $("dl-panel").hidden = watchTab !== "dl";
+  $("ml-panel").hidden = watchTab !== "ml";
+  $("hist-strat").style.visibility = extra ? "hidden" : "visible";
+  if (watchTab === "dl") $("grid-meta").textContent = "CSV / ZIP / Sheets — pick From and To (IST)";
+  if (watchTab === "ml") $("grid-meta").textContent = "S11 ML packs — Approve → paper, then type RESTART";
 }
 function rangeQs() {
   const from = $("exp-from").value;
@@ -444,8 +522,161 @@ async function bootExports() {
     await refreshExportMeta();
   } catch (e) { flash("flash-dl", String(e.message || e), true); }
 }
+function setMlBadge(n) {
+  const el = $("ml-badge");
+  if (!el) return;
+  el.textContent = n ? " (" + n + ")" : "";
+}
+function renderMl() {
+  const d = lastMl || {};
+  const s11 = d.s11 || {};
+  const pack = s11.pack || {};
+  const props = d.proposals || {};
+  const pendingAll = props.pending || [];
+  const decided = props.decided || [];
+  const packs = d.packs || [];
+  const disc = d.discover || {};
+  const sc = scoreFor("S11_DISCOVERED");
+  const filter = ($("ml-filter") && $("ml-filter").value) || "";
+  const pending = filter ? pendingAll.filter((p) => p.strategy === filter) : pendingAll;
+  setMlBadge(pendingAll.length);
+  const restart = $("ml-restart");
+  if (restart) restart.hidden = !mlRestartNeeded;
+  $("ml-loaded").innerHTML = `<div class="ml-card">
+    <h3>Loaded S11 pack</h3>
+    <p class="ml-meta">${esc(s11.load_hint || "—")}</p>
+    <div class="ml-stats">
+      ${mlStat("In .env", s11.enable_s11 ? "ENABLE_S11" : "off", s11.enable_s11 ? "ok" : "warn")}
+      ${mlStat("DRY_RUN", s11.dry_run === false ? "false" : "true", s11.dry_run === false ? "bad" : "ok")}
+      ${mlStat("Tape WR%", sc.win_rate != null ? pct(sc.win_rate) : "—")}
+      ${mlStat("Tape ₹", sc.pnl_after_tax != null ? money(sc.pnl_after_tax) : "—", pnlClass(sc.pnl_after_tax))}
+      ${mlStat("Closed", sc.closed != null ? fmt(sc.closed, 0) : "—")}
+    </div>
+    <p class="mono">${esc(s11.pack_path || "(S11_PACK_PATH empty)")}</p>
+    <p class="ml-meta">${packLine(pack)} · buy≥${esc(pack.buy_prob ?? "—")} short≤${esc(pack.short_prob ?? "—")} hold ${esc(pack.min_hold_sec ?? "—")}s every ${esc(pack.every_n_ticks ?? "—")}</p>
+    ${pack.rationale ? `<p class="hint">${esc(pack.rationale)}</p>` : ""}
+    ${pack.behavior_summary ? `<p class="hint">${esc(pack.behavior_summary)}</p>` : ""}
+  </div>`;
+  $("ml-pending").innerHTML = pending.map((p) => {
+    const paper = p.paper || {};
+    const proposed = p.proposed_pack || {};
+    const loaded = s11.pack || {};
+    const extra = p.extra || (paper.extra || {});
+    const delta = paper.delta_vs_baseline_inr;
+    const safety = p.safety_ok ? pill("safety ok", "ok") : pill("safety fail", "bad");
+    const kind = pill(p.kind || "new", p.kind === "new" ? "ok" : "warn");
+    const same = p.same_as_loaded ? pill("same as loaded", "ok") : "";
+    const disable = p.would_disable_s11 ? pill("would disable S11", "warn") : "";
+    const reasons = (p.safety_reasons || []).join(", ");
+    const env = p.env_patch ? JSON.stringify(p.env_patch, null, 2) : "";
+    return `<div class="ml-card" data-prop="${esc(p.id)}">
+      <h3>${esc(p.title || p.strategy)}</h3>
+      <p class="ml-meta">${esc(p.id)} · ${esc(p.strategy)} · week ${esc(p.week_id || "—")} · ${kind} ${safety} ${same} ${disable}</p>
+      <p>${esc(p.summary || "")}</p>
+      ${reasons ? `<p class="hint">Safety: ${esc(reasons)}</p>` : ""}
+      <div class="ml-stats">
+        ${mlStat("Trades", paper.n_trades != null ? fmt(paper.n_trades, 0) : "—")}
+        ${mlStat("Win", wrFrac(paper.win_rate))}
+        ${mlStat("Gross ₹", money(paper.gross_pnl_inr), pnlClass(paper.gross_pnl_inr))}
+        ${mlStat("After-tax ₹", money(paper.after_tax_pnl_inr), pnlClass(paper.after_tax_pnl_inr))}
+        ${mlStat("Δ vs base", delta != null ? money(delta) : "—", pnlClass(delta))}
+      </div>
+      <div class="ml-compare">
+        <div class="ml-box"><b>Loaded now</b><span class="mono">${esc(loaded.path || s11.pack_path || "—")}</span><div class="ml-meta">${packLine(loaded)}</div></div>
+        <div class="ml-box"><b>This proposal</b><span class="mono">${esc(proposed.path || p.model_path || "—")}</span><div class="ml-meta">${packLine(proposed)}${extra.auc != null ? " · extra AUC " + aucStr(extra.auc) : ""}</div></div>
+      </div>
+      ${env ? `<pre class="env">${esc(env)}</pre>` : ""}
+      <textarea data-note="${esc(p.id)}" placeholder="Decision note"></textarea>
+      ${p.safety_ok === false ? `<label class="chk" style="margin-top:.4rem"><input type="checkbox" data-unsafe="${esc(p.id)}"/> Accept risk (safety_ok=false)</label>` : ""}
+      <div class="row" style="margin-top:.5rem">
+        <button class="btn ok" type="button" data-ml="approve" data-id="${esc(p.id)}">Approve → paper</button>
+        <button class="btn" type="button" data-ml="live" data-id="${esc(p.id)}">Approve → live</button>
+        <button class="btn danger" type="button" data-ml="reject" data-id="${esc(p.id)}">Reject</button>
+      </div>
+    </div>`;
+  }).join("") || `<p class="hint">${pendingAll.length ? "No pending rows for this filter." : "No pending proposals. Run weekly_discover.sh on the VM (Sunday job)."}</p>`;
+  $("ml-packs").innerHTML = packs.length ? `<table>
+    <thead><tr><th>Pack</th><th>Model</th><th class="num">AUC</th><th>Safety</th><th class="num">Paper ₹</th><th></th></tr></thead>
+    <tbody>${packs.map((row) => `<tr>
+      <td>${row.is_loaded ? pill("loaded", "ok") + " " : ""}<span class="mono">${esc((row.path || "").replace("data/discover/packs/", ""))}</span></td>
+      <td>${esc(row.model_name || "—")} ${esc(row.family || "")}</td>
+      <td class="num">${aucStr(row.auc)}</td>
+      <td>${row.safety_ok ? pill("ok", "ok") : pill("fail", "bad")}</td>
+      <td class="num ${pnlClass((row.paper || {}).after_tax_pnl)}">${money((row.paper || {}).after_tax_pnl)}</td>
+      <td><button class="btn ok" type="button" data-ml="load" data-path="${esc(row.path)}" data-safe="${row.safety_ok ? "1" : "0"}">${row.is_loaded ? "Reload" : "Load"}</button></td>
+    </tr>`).join("")}</tbody>
+  </table>` : `<p class="hint">No packs yet under data/discover/packs.</p>`;
+  const cands = disc.candidates || [];
+  $("ml-discover").innerHTML = `<div class="ml-card">
+    <p class="ml-meta">${esc(disc.report_path || "no latest_report.json")} ${disc.report_mtime_ist ? "· " + esc(disc.report_mtime_ist) : ""}</p>
+    ${disc.behavior_summary ? `<p>${esc(disc.behavior_summary)}</p>` : `<p class="hint">No discovery report yet. Cron: Sunday 19:00 IST weekly_discover.sh</p>`}
+    ${cands.length ? `<table style="margin-top:.45rem"><thead><tr><th>Model</th><th>Template</th><th class="num">AUC</th><th class="num">Trades</th><th class="num">After-tax</th><th>Safety</th><th></th></tr></thead><tbody>
+      ${cands.map((c) => `<tr>
+        <td>${esc(c.model || "")}</td>
+        <td>${esc(c.template || "")} ${esc(c.family || "")}</td>
+        <td class="num">${aucStr(c.auc)}</td>
+        <td class="num">${fmt(c.n_trades, 0)}</td>
+        <td class="num ${pnlClass(c.after_tax_pnl)}">${money(c.after_tax_pnl)}</td>
+        <td>${c.safety_ok ? pill("ok", "ok") : pill("fail", "bad")}</td>
+        <td>${c.pack_path ? `<button class="btn ok" type="button" data-ml="load" data-path="${esc(c.pack_path)}" data-safe="${c.safety_ok ? "1" : "0"}">Load</button>` : ""}</td>
+      </tr>`).join("")}
+    </tbody></table>` : ""}
+    ${disc.cron_tail ? `<pre class="env">${esc(disc.cron_tail)}</pre>` : ""}
+  </div>`;
+  $("ml-decided").innerHTML = decided.length ? `<table>
+    <thead><tr><th>When</th><th>Book</th><th>Decision</th><th>Title</th><th>Note</th></tr></thead>
+    <tbody>${decided.slice(0, 20).map((p) => `<tr>
+      <td>${esc(String(p.decided_at_ist || "").slice(0, 19))}</td>
+      <td>${esc(SHORT[p.strategy] || p.strategy || "")}</td>
+      <td>${esc(p.status || "")}</td>
+      <td>${esc(p.title || "")}</td>
+      <td>${esc(p.decision_note || "")}</td>
+    </tr>`).join("")}</tbody>
+  </table>` : `<p class="hint">No decisions yet.</p>`;
+}
+async function loadMl() {
+  lastMl = await api("/api/ml");
+  setMlBadge(((lastMl.proposals || {}).pending || []).length);
+  if (watchTab === "ml") renderMl();
+  const n = ((lastMl.proposals || {}).pending || []).length;
+  const lr = (lastWhy && lastWhy.learner) || {};
+  $("foot-ml").textContent = (n ? ("ML pending " + n + " · ") : "") + (lr.line || lr.note || "learner cold");
+}
+async function decideMl(id, decision) {
+  const noteEl = document.querySelector(`[data-note="${id}"]`);
+  const unsafeEl = document.querySelector(`[data-unsafe="${id}"]`);
+  const body = {
+    decision,
+    note: noteEl ? noteEl.value : "",
+    accept_unsafe: !!(unsafeEl && unsafeEl.checked),
+  };
+  const res = await api("/api/proposals/" + encodeURIComponent(id) + "/decide", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (res.ml) lastMl = res.ml;
+  if (res.restart_needed) mlRestartNeeded = true;
+  flash("flash-ml", res.reminder || res.note || (decision === "rejected" ? "Rejected" : "Approved → paper"));
+  renderMl();
+  await loadDesk();
+}
+async function loadPack(path, alreadySafe) {
+  const unsafe = alreadySafe === false;
+  if (unsafe) {
+    const ok = window.confirm("This pack failed safety gates. Load it into paper anyway? DRY_RUN stays true.");
+    if (!ok) return;
+  }
+  const res = await api("/api/s11/activate", {
+    method: "POST",
+    body: JSON.stringify({ pack_path: path, accept_unsafe: unsafe }),
+  });
+  if (res.restart_needed) mlRestartNeeded = true;
+  flash("flash-ml", res.reminder || "Pack written to .env");
+  await loadMl();
+  await loadDesk();
+}
 function renderGrid() {
-  if (watchTab === "dl") return;
+  if (watchTab === "dl" || watchTab === "ml") return;
   const h = Object.assign({}, lastTape, lastHist);
   const tab = watchTab;
   const strat = $("hist-strat").value;
@@ -629,7 +860,30 @@ document.querySelectorAll("#tabs .tab").forEach((btn) => {
     showMainTab();
     renderGrid();
     if (watchTab === "why" && !lastWhy) loadWhy().catch(() => {});
+    if (watchTab === "ml") loadMl().catch((e) => flash("flash-ml", String(e.message || e), true));
   };
+});
+$("ml-filter").onchange = () => { if (lastMl) renderMl(); };
+$("btn-ml-refresh").onclick = () => loadMl().catch((e) => flash("flash-ml", String(e.message || e), true));
+$("ml-panel").addEventListener("click", (ev) => {
+  const btn = ev.target.closest("button[data-ml]");
+  if (!btn) return;
+  const kind = btn.dataset.ml;
+  if (kind === "approve") {
+    decideMl(btn.dataset.id, "approved_paper").catch((e) => flash("flash-ml", String(e.message || e), true));
+    return;
+  }
+  if (kind === "reject") {
+    decideMl(btn.dataset.id, "rejected").catch((e) => flash("flash-ml", String(e.message || e), true));
+    return;
+  }
+  if (kind === "live") {
+    flash("flash-ml", (lastMl && lastMl.live_blocked_reason) || "Live approval is not on this tab. Paper first, then Unlock live on Live money.", true);
+    return;
+  }
+  if (kind === "load") {
+    loadPack(btn.dataset.path, btn.dataset.safe !== "0").catch((e) => flash("flash-ml", String(e.message || e), true));
+  }
 });
 $("exp-from").onchange = () => refreshExportMeta().catch(() => {});
 $("exp-to").onchange = () => refreshExportMeta().catch(() => {});
@@ -679,6 +933,9 @@ $("btn-bot-restart").onclick = () => {
   const word = $("restart-word").value.trim();
   if (word !== "RESTART") { flash("flash-engine", "Type RESTART", true); return; }
   $("restart-word").value = "";
+  mlRestartNeeded = false;
+  const banner = $("ml-restart");
+  if (banner) banner.hidden = true;
   act("flash-engine", "/api/bot/restart", { confirm: word }, "Bot restarted");
 };
 $("btn-feed-start").onclick = () => act("flash-engine", "/api/feed/start", {}, "Feed-only started");
@@ -706,15 +963,22 @@ $("btn-save-cap").onclick = () => act("flash-money", "/api/capital", {
 
 tickClock();
 setInterval(tickClock, 1000);
+if (location.hash === "#ml") {
+  watchTab = "ml";
+  document.querySelectorAll("#tabs .tab").forEach((b) => b.classList.toggle("on", b.dataset.tab === "ml"));
+  showMainTab();
+}
 bootExports().catch((e) => flash("flash-dl", String(e.message || e), true));
 loadDesk().catch((e) => flash("flash-engine", String(e.message || e), true));
 loadTape().catch(() => {});
 loadHistory().catch(() => {});
 setTimeout(() => loadWhy().catch(() => {}), 400);
+loadMl().catch(() => {});
 setInterval(() => { if (!typing()) loadDesk().catch(() => {}); }, 5000);
 setInterval(() => { if (!typing()) loadTape().catch(() => {}); }, 3000);
 setInterval(() => { if (!typing()) loadHistory().catch(() => {}); }, 12000);
 setInterval(() => { if (!typing()) loadWhy().catch(() => {}); }, 20000);
+setInterval(() => { if (!typing()) loadMl().catch(() => {}); }, 15000);
 </script>
 </body>
 </html>

--- a/goldpetal/test_desk.py
+++ b/goldpetal/test_desk.py
@@ -19,6 +19,12 @@ def test_station_is_the_operator_page() -> None:
     assert "Positions" in html
     assert "Blotter" in html
     assert "Downloads" in html
+    assert 'data-tab="ml"' in html
+    assert "Approve → paper" in html
+    assert "/api/ml" in html
+    assert "/api/s11/activate" in html
+    assert "/api/proposals/" in html
+    assert "S11_PACK_PATH" in html
     assert "Download all (ZIP)" in html
     assert "Copy trades → Sheets" in html
     assert "/api/export/pack.zip" in html
@@ -54,6 +60,8 @@ def test_lite_html_is_compact_controls() -> None:
     assert "Start bot" in html
     assert "Save strategies" in html
     assert "Trading station" in html
+    assert "ML / S11" in html
+    assert "/api/ml" in html
     assert "Watch" not in html
     assert "Download all (ZIP)" not in html
     assert "/api/history" not in html
@@ -86,6 +94,9 @@ def test_control_panel_serves_station_on_8501() -> None:
     assert "LITE_HTML_PATH" in text
     assert "/lite" in text
     assert "/api/desk" in text
+    assert "/api/ml" in text
+    assert "/api/s11/activate" in text
+    assert "decide_proposal_for_desk" in text
     assert "/api/tape" in text
     assert "/api/s14/calc" in text
     assert "/api/analysis" in text

--- a/goldpetal/test_s11_desk.py
+++ b/goldpetal/test_s11_desk.py
@@ -1,0 +1,308 @@
+"""S11 ML approvals on the HTML desk: paper-safe env apply + pack inspector."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from analytics.env_bridge import read_env
+from control_state import load_state
+from proposals import PaperResult, StrategyProposal, add_proposal
+from s11_desk import (
+    LIVE_BLOCKED_REASON,
+    activate_s11_pack,
+    decide_proposal_for_desk,
+    list_s11_packs,
+    ml_desk_payload,
+    pack_summary,
+    paper_safe_env_patch,
+    to_env_pack_path,
+)
+
+
+def _write_pack(path: Path, *, safety_ok: bool = True, auc: float = 0.62) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "id": path.stem,
+        "week_id": "2026-W33",
+        "strategy": "S11_DISCOVERED",
+        "model_name": "logreg",
+        "model_path": "data/discover/models/demo.joblib",
+        "features": ["ret_1", "imb_l1", "spread"],
+        "buy_prob": 0.58,
+        "short_prob": 0.42,
+        "min_hold_sec": 30,
+        "every_n_ticks": 5,
+        "min_imb": 0.0,
+        "family": "book",
+        "rationale": "imbalance follows",
+        "auc": auc,
+        "paper": {
+            "n_trades": 12,
+            "win_rate": 0.58,
+            "gross_pnl": 410.0,
+            "after_tax_pnl": 280.0,
+        },
+        "safety_ok": safety_ok,
+        "safety_reasons": ["auc=0.62 ok"] if safety_ok else ["auc=0.40<0.55"],
+        "behavior_summary": "book imbalance leads short-horizon ticks.",
+        "created_at_ist": "2026-08-17T19:00:00+05:30",
+    }
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def test_paper_safe_patch_keeps_dry_run_and_blocks_s4() -> None:
+    clean, skipped = paper_safe_env_patch(
+        {
+            "ENABLE_S11": "true",
+            "S11_PACK_PATH": "data/discover/packs/demo.json",
+            "DRY_RUN": "false",
+            "ENABLE_S4": "true",
+            "LIVE_UNLOCK": "true",
+        }
+    )
+    assert clean["DRY_RUN"] == "true"
+    assert clean["ENABLE_S11"] == "true"
+    assert clean["S11_PACK_PATH"] == "data/discover/packs/demo.json"
+    assert "ENABLE_S4" not in clean
+    assert "DRY_RUN" in skipped
+    assert skipped["ENABLE_S4"]
+    assert skipped["LIVE_UNLOCK"]
+
+
+def test_pack_summary_and_list(tmp_path: Path) -> None:
+    packs = tmp_path / "data" / "discover" / "packs"
+    one = _write_pack(packs / "logreg_book_20260817.json")
+    (tmp_path / "data" / "discover" / "models").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "data" / "discover" / "models" / "demo.joblib").write_bytes(b"joblib")
+    row = pack_summary(one, root=tmp_path)
+    assert row["exists"] is True
+    assert row["model_name"] == "logreg"
+    assert row["auc"] == 0.62
+    assert row["n_features"] == 3
+    assert row["path"] == "data/discover/packs/logreg_book_20260817.json"
+    listed = list_s11_packs(root=tmp_path)
+    assert len(listed) == 1
+    assert listed[0]["id"] == "logreg_book_20260817"
+
+
+def test_approve_paper_writes_s11_pack_and_keeps_dry_run(tmp_path: Path) -> None:
+    packs = tmp_path / "data" / "discover" / "packs"
+    pack = _write_pack(packs / "week.json")
+    env_key = to_env_pack_path(pack, root=tmp_path)
+    env = tmp_path / ".env"
+    env.write_text("DRY_RUN=true\nENABLE_S11=false\nENABLE_S4=false\n", encoding="utf-8")
+    props = tmp_path / "control" / "proposals.json"
+    state = tmp_path / "control" / "state.json"
+    add_proposal(
+        StrategyProposal(
+            id="s11ok",
+            week_id="2026-W33",
+            kind="new",
+            strategy="S11_DISCOVERED",
+            title="S11 behavior+ML demo",
+            summary="pack ready",
+            paper=PaperResult(n_trades=12, win_rate=0.58, after_tax_pnl_inr=280.0),
+            safety_ok=True,
+            env_patch={
+                "ENABLE_S11": "true",
+                "S11_PACK_PATH": env_key,
+                "DRY_RUN": "false",
+                "ENABLE_S4": "true",
+            },
+        ),
+        path=props,
+    )
+    res = decide_proposal_for_desk(
+        "s11ok",
+        "approved_paper",
+        note="paper it",
+        proposals_path=props,
+        state_path=state,
+        env_path=env,
+        root=tmp_path,
+    )
+    assert res["ok"] is True
+    assert res["restart_needed"] is True
+    applied = (res["env_applied"] or {}).get("applied") or {}
+    assert applied["S11_PACK_PATH"] == env_key
+    assert applied["ENABLE_S11"] == "true"
+    assert applied["DRY_RUN"] == "true"
+    skipped = (res["env_applied"] or {}).get("skipped") or {}
+    assert "ENABLE_S4" in skipped
+    snap = read_env(env)
+    assert snap["S11_PACK_PATH"] == env_key
+    assert snap["DRY_RUN"] == "true"
+    assert snap["ENABLE_S4"] == "false"
+    st = load_state(path=state)
+    assert "S11_DISCOVERED" in st.paper_approved
+
+
+def test_unsafe_approve_requires_accept(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("DRY_RUN=true\n", encoding="utf-8")
+    props = tmp_path / "control" / "proposals.json"
+    state = tmp_path / "control" / "state.json"
+    add_proposal(
+        StrategyProposal(
+            id="s11bad",
+            week_id="2026-W33",
+            kind="new",
+            strategy="S11_DISCOVERED",
+            title="unsafe",
+            summary="gates failed",
+            paper=PaperResult(n_trades=2, after_tax_pnl_inr=-20.0),
+            safety_ok=False,
+            env_patch={"ENABLE_S11": "false", "S11_PACK_PATH": "", "DRY_RUN": "true"},
+        ),
+        path=props,
+    )
+    blocked = decide_proposal_for_desk(
+        "s11bad",
+        "approved_paper",
+        proposals_path=props,
+        state_path=state,
+        env_path=env,
+        root=tmp_path,
+    )
+    assert blocked["ok"] is False
+    assert "safety_ok=False" in blocked["error"]
+    ok = decide_proposal_for_desk(
+        "s11bad",
+        "approved_paper",
+        accept_unsafe=True,
+        proposals_path=props,
+        state_path=state,
+        env_path=env,
+        root=tmp_path,
+    )
+    assert ok["ok"] is True
+    assert ok["status"] == "approved_paper"
+
+
+def test_approve_live_is_blocked(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("DRY_RUN=true\n", encoding="utf-8")
+    props = tmp_path / "control" / "proposals.json"
+    state = tmp_path / "control" / "state.json"
+    add_proposal(
+        StrategyProposal(
+            id="s11live",
+            week_id="2026-W33",
+            kind="new",
+            strategy="S11_DISCOVERED",
+            title="live no",
+            summary="no",
+            paper=PaperResult(),
+            safety_ok=True,
+            env_patch={"DRY_RUN": "false", "ENABLE_S11": "true"},
+        ),
+        path=props,
+    )
+    res = decide_proposal_for_desk(
+        "s11live",
+        "approved_live",
+        proposals_path=props,
+        state_path=state,
+        env_path=env,
+        root=tmp_path,
+    )
+    assert res["ok"] is False
+    assert "DRY_RUN=false" in res["error"] or "Live approval" in res["error"]
+    from proposals import get_proposal
+
+    still = get_proposal("s11live", path=props)
+    assert still is not None
+    assert still.status == "pending"
+    assert read_env(env)["DRY_RUN"] == "true"
+    st = load_state(path=state)
+    assert "S11_DISCOVERED" not in (st.live_approved or [])
+
+
+def test_activate_pack_and_ml_payload(tmp_path: Path) -> None:
+    packs = tmp_path / "data" / "discover" / "packs"
+    pack = _write_pack(packs / "loadme.json")
+    (tmp_path / "data" / "discover" / "models").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "data" / "discover" / "models" / "demo.joblib").write_bytes(b"x")
+    env = tmp_path / ".env"
+    env.write_text("DRY_RUN=true\nENABLE_S11=false\n", encoding="utf-8")
+    res = activate_s11_pack(str(pack), env_path=env, root=tmp_path)
+    assert res["ok"] is True
+    assert res["restart_needed"] is True
+    assert read_env(env)["S11_PACK_PATH"] == "data/discover/packs/loadme.json"
+    assert read_env(env)["ENABLE_S11"] == "true"
+    payload = ml_desk_payload(root=tmp_path, env_path=env, proposals_path=tmp_path / "none.json")
+    # none.json missing → proposals_snapshot creates empty store
+    assert payload["s11"]["enable_s11"] is True
+    assert payload["s11"]["pack"]["id"] == "loadme"
+    assert payload["live_blocked"] is True
+    assert LIVE_BLOCKED_REASON in payload["live_blocked_reason"]
+    assert any(p["is_loaded"] for p in payload["packs"])
+
+
+def test_activate_unsafe_pack_requires_accept(tmp_path: Path) -> None:
+    packs = tmp_path / "data" / "discover" / "packs"
+    pack = _write_pack(packs / "unsafe.json", safety_ok=False, auc=0.41)
+    env = tmp_path / ".env"
+    env.write_text("DRY_RUN=true\n", encoding="utf-8")
+    blocked = activate_s11_pack(str(pack), env_path=env, root=tmp_path)
+    assert blocked["ok"] is False
+    ok = activate_s11_pack(str(pack), accept_unsafe=True, env_path=env, root=tmp_path)
+    assert ok["ok"] is True
+
+
+def test_reject_does_not_write_env(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("DRY_RUN=true\nENABLE_S11=false\n", encoding="utf-8")
+    props = tmp_path / "control" / "proposals.json"
+    state = tmp_path / "control" / "state.json"
+    add_proposal(
+        StrategyProposal(
+            id="nope",
+            week_id="2026-W33",
+            kind="new",
+            strategy="S11_DISCOVERED",
+            title="no",
+            summary="no",
+            paper=PaperResult(),
+            safety_ok=True,
+            env_patch={"ENABLE_S11": "true", "S11_PACK_PATH": "data/discover/packs/x.json"},
+        ),
+        path=props,
+    )
+    res = decide_proposal_for_desk(
+        "nope",
+        "rejected",
+        proposals_path=props,
+        state_path=state,
+        env_path=env,
+        root=tmp_path,
+    )
+    assert res["ok"] is True
+    assert res["env_applied"] is None
+    assert "S11_PACK_PATH" not in read_env(env)
+    st = load_state(path=state)
+    assert "S11_DISCOVERED" in st.force_disabled
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    test_paper_safe_patch_keeps_dry_run_and_blocks_s4()
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td)
+        test_pack_summary_and_list(p)
+    with tempfile.TemporaryDirectory() as td:
+        test_approve_paper_writes_s11_pack_and_keeps_dry_run(Path(td))
+    with tempfile.TemporaryDirectory() as td:
+        test_unsafe_approve_requires_accept(Path(td))
+    with tempfile.TemporaryDirectory() as td:
+        test_approve_live_is_blocked(Path(td))
+    with tempfile.TemporaryDirectory() as td:
+        test_activate_pack_and_ml_payload(Path(td))
+    with tempfile.TemporaryDirectory() as td:
+        test_activate_unsafe_pack_requires_accept(Path(td))
+    with tempfile.TemporaryDirectory() as td:
+        test_reject_does_not_write_env(Path(td))
+    print("all s11 desk tests passed")

--- a/goldpetal/test_s11_desk.py
+++ b/goldpetal/test_s11_desk.py
@@ -286,6 +286,48 @@ def test_reject_does_not_write_env(tmp_path: Path) -> None:
     assert "S11_DISCOVERED" in st.force_disabled
 
 
+def test_joblib_model_path_does_not_crash_ml_tab(tmp_path: Path) -> None:
+    """Weekend proposals store the .joblib on model_path; pickle starts with 0x80."""
+    models = tmp_path / "data" / "discover" / "models"
+    models.mkdir(parents=True)
+    joblib = models / "logreg_book.joblib"
+    joblib.write_bytes(b"\x80\x04\x95joblib")
+    row = pack_summary(str(joblib), root=tmp_path)
+    assert row["error"]
+    assert "utf-8" not in row["error"]
+    fake_json = tmp_path / "data" / "discover" / "packs" / "notjson.json"
+    fake_json.parent.mkdir(parents=True, exist_ok=True)
+    fake_json.write_bytes(b"\x80\x04\x95joblib")
+    row_json = pack_summary(fake_json, root=tmp_path)
+    assert row_json["exists"] is True
+    assert "utf-8" not in (row_json.get("error") or "")
+    assert "pickle" in (row_json.get("error") or "") or "binary" in (row_json.get("error") or "")
+
+    env = tmp_path / ".env"
+    env.write_text("DRY_RUN=true\nENABLE_S11=true\nS11_PACK_PATH=\n", encoding="utf-8")
+    props = tmp_path / "control" / "proposals.json"
+    add_proposal(
+        StrategyProposal(
+            id="s11job",
+            week_id="2026-W33",
+            kind="new",
+            strategy="S11_DISCOVERED",
+            title="S11 joblib fallback",
+            summary="safety failed so pack path empty",
+            paper=PaperResult(),
+            safety_ok=False,
+            model_path=str(joblib),
+            env_patch={"ENABLE_S11": "false", "S11_PACK_PATH": "", "DRY_RUN": "true"},
+        ),
+        path=props,
+    )
+    payload = ml_desk_payload(root=tmp_path, env_path=env, proposals_path=props)
+    assert payload["ok"] is True
+    pending = payload["proposals"]["pending"]
+    assert len(pending) == 1
+    assert pending[0]["proposed_pack"].get("error") == "empty"
+
+
 if __name__ == "__main__":
     import tempfile
 
@@ -305,4 +347,6 @@ if __name__ == "__main__":
         test_activate_unsafe_pack_requires_accept(Path(td))
     with tempfile.TemporaryDirectory() as td:
         test_reject_does_not_write_env(Path(td))
+    with tempfile.TemporaryDirectory() as td:
+        test_joblib_model_path_does_not_crash_ml_tab(Path(td))
     print("all s11 desk tests passed")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Streamlit **Proposals** tab used to approve weekend S11 packs (write `S11_PACK_PATH` + `ENABLE_S11`, then restart the bot). The HTML station on 8501 had no UI for that, and `/api/proposals/.../decide` did not apply the env patch — so S11 stayed disabled even when it was in the paper book list.

## What you get on the desk

New center tab **ML** (also `/#ml`, plus a compact list on `/lite`):

- Pending cards like Streamlit: title, summary, safety badge, paper trades / win / gross / after-tax / Δ vs baseline, env patch JSON, decision note
- **Loaded pack vs this proposal** (model, family, AUC, buy/short thresholds)
- Packs on disk under `data/discover/packs` — **Load** writes the same paper env without a proposal row
- Last `weekly_discover.sh` report (`latest_report.json` + cron tail)
- Live S11 tape WR% / after-tax ₹ from the scoreboard
- Restart banner after approve: type **RESTART** on Engine (desk restart is not enough)

Follow-up: the tab no longer tries to read weekend `.joblib` model files as UTF-8 (that was the `byte 0x80` crash).

## Safety (same paper rules as the rest of the desk)

- Approve → paper **auto-writes** whitelist `.env` keys and **forces `DRY_RUN=true`**
- Approve → live is blocked here (Unlock live stays on Live money)
- `safety_ok=false` needs **Accept risk**
- This tab cannot turn S4 / S12 / S14 / S15 back on

Paper books stay S5 / S8 / S11 / S13 / S16. After pull: `./scripts/run_desk_vm.sh --restart`, open **ML**, approve a pack, then type **RESTART** on the bot.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e92370bb-ed6a-433d-8b83-fe612227a4b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e92370bb-ed6a-433d-8b83-fe612227a4b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

