### PR TITLE
Drop S4 from the desk; paper daily swing is S13

### DIFF
--- a/goldpetal/analytics/VM_DESK.md
+++ b/goldpetal/analytics/VM_DESK.md
@@ -110,15 +110,17 @@ git pull origin cursor/s14-wick-length-a4b2
 ./scripts/run_desk_vm.sh --restart
 ```
 
-## S4 daily HH/LL swing (research only)
+## S4 daily HH/LL swing (off — not on the desk)
 
-Angel + ticks daily backtest picked **S13**, not S4. Leave S4 off.
+Angel + ticks daily backtest picked **S13**, not S4. S4 is off and **not on
+the station book list**. Save strategies cannot turn it on.
 
 ```bash
 ENABLE_S4=false
 ```
 
 Overnight ML (`weekly_s4.sh` / `strategy_overnight.py`) is research-only.
+The swing module stays in the repo for backtests only.
 
 ## S13 daily S16 (paper — the day-by-day book)
 
@@ -270,7 +272,7 @@ Prints a day table (`prevH` / `prevL` / HH / LL / signal) and writes
 
 ## Paper allowlist (stop S9 etc.)
 
-On **8787 Live money**, Save ENABLE_* with only the slim books checked (S4/S5/S8/S11/S13/S16). That writes `ENABLE_S9=false` (and S1/S2/S3/S6/S10/S12/S14/S15) then Restart supervise on 8787.
+On **8501 Live money**, Save ENABLE_* with only the slim books checked (S5/S8/S11/S13/S16). That writes `ENABLE_S4=false` and `ENABLE_S9=false` (and S1/S2/S3/S6/S10/S12/S14/S15) then Restart the bot.
 
 Trades tab may still show **old** S9 history — filter to slim strategies.
 

--- a/goldpetal/analytics/app.py
+++ b/goldpetal/analytics/app.py
@@ -68,9 +68,8 @@ LOCAL_DESK = os.getenv("GP_DESK_LOCAL", "").strip().lower() in {"1", "true", "ye
     DEFAULT_DATA.resolve() == (ROOT / "data").resolve()
 )
 
-# Slim paper set (S4/S5/S8/S11/S13/S16)
+# Slim paper set (S5/S8/S11/S13/S16). S4 stayed off after the daily backtest.
 STRATEGIES = [
-    "S4_OVERNIGHT",
     "S5_MINEDGE",
     "S8_NET_ZIGZAG",
     "S11_DISCOVERED",
@@ -427,7 +426,7 @@ def tab_overview(dd: Path, db: Path, *, lot_size: float = 1.0) -> None:
                 orphan = int(r.get("orphan_open") or 0)
                 st.caption(
                     f"Slim open positions: **{open_n}** "
-                    f"(S4/S5/S8/S11/S13/S16 only)."
+                    f"(S5/S8/S11/S13/S16 only)."
                     + (
                         f" Also {orphan} leftover OPEN from disabled strategies "
                         f"(S9/S10/…) — not active now; see expander below."

--- a/goldpetal/analytics/local_bridge.py
+++ b/goldpetal/analytics/local_bridge.py
@@ -7,7 +7,6 @@ from typing import Any
 
 
 SLIM_STRATEGIES = (
-    "S4_OVERNIGHT",
     "S5_MINEDGE",
     "S8_NET_ZIGZAG",
     "S11_DISCOVERED",

--- a/goldpetal/capital.py
+++ b/goldpetal/capital.py
@@ -92,7 +92,7 @@ def default_plan() -> CapitalPlan:
     each = round(deployable / len(DEFAULT_STRATEGIES), 2)
     strats = {}
     for name in DEFAULT_STRATEGIES:
-        # Slim paper books (S4/S5/S8/S11/S13/S16) sized at PAPER_LOTS (100).
+        # Slim paper books (S5/S8/S11/S13/S16) sized at PAPER_LOTS (100).
         lots = 100 if name in _HUNDRED_LOT else 10
         strats[name] = StrategyBudget(
             strategy=name, budget_inr=each, max_lots=lots

--- a/goldpetal/control_state.py
+++ b/goldpetal/control_state.py
@@ -212,7 +212,6 @@ ALL_STRATEGY_NAMES: tuple[str, ...] = (
 )
 
 SLIM_PAPER_STRATEGIES: tuple[str, ...] = (
-    "S4_OVERNIGHT",
     "S5_MINEDGE",
     "S8_NET_ZIGZAG",
     "S11_DISCOVERED",

--- a/goldpetal/desk.html
+++ b/goldpetal/desk.html
@@ -258,7 +258,7 @@ td { padding: .4rem; border-bottom: 1px solid var(--line); vertical-align: middl
 <script>
 const $ = (id) => document.getElementById(id);
 const PAPER_BOOKS = [
-  "S4_OVERNIGHT", "S5_MINEDGE", "S8_NET_ZIGZAG",
+  "S5_MINEDGE", "S8_NET_ZIGZAG",
   "S11_DISCOVERED", "S13_HHHL_DAY", "S16_HHHL_WICK_1H",
 ];
 const SHORT = {

--- a/goldpetal/live_readiness.py
+++ b/goldpetal/live_readiness.py
@@ -23,6 +23,9 @@ PANEL_LIVE_MAX_LOTS = 10
 LIVE_CONFIRM_WORD = "LIVE"
 RESTART_CONFIRM_WORD = "RESTART"
 
+# S4 daily HH/LL lost the Angel/ticks backtest to S13 (daily S16). Stay off.
+DESK_FORCE_OFF = frozenset({"S4_OVERNIGHT"})
+
 
 def _truthy(raw: str | None, default: str = "true") -> bool:
     v = (raw if raw is not None else default).strip().lower()
@@ -157,7 +160,11 @@ def apply_panel_enables(
     from analytics.env_bridge import STRATEGY_ENABLE, apply_strategy_enables
 
     known = list(STRATEGY_ENABLE.keys())
-    want = [str(n).strip() for n in enabled_names if str(n).strip() in STRATEGY_ENABLE]
+    want = [
+        str(n).strip()
+        for n in enabled_names
+        if str(n).strip() in STRATEGY_ENABLE and str(n).strip() not in DESK_FORCE_OFF
+    ]
     res = apply_strategy_enables(want, known=known, path=path)
     res["enabled"] = want
     res["restart_needed"] = True

--- a/goldpetal/station.html
+++ b/goldpetal/station.html
@@ -237,7 +237,6 @@ label.chk { display: flex; gap: .35rem; align-items: center; color: var(--muted)
             <option value="S11_DISCOVERED">S11 pack</option>
             <option value="S8_NET_ZIGZAG">S8 zigzag</option>
             <option value="S5_MINEDGE">S5 minedge</option>
-            <option value="S4_OVERNIGHT">S4 (research)</option>
           </select>
           <button class="btn" type="button" id="btn-ml-refresh">Refresh</button>
         </div>
@@ -327,7 +326,7 @@ label.chk { display: flex; gap: .35rem; align-items: center; color: var(--muted)
 <script>
 const $ = (id) => document.getElementById(id);
 const PAPER_BOOKS = [
-  "S4_OVERNIGHT", "S5_MINEDGE", "S8_NET_ZIGZAG",
+  "S5_MINEDGE", "S8_NET_ZIGZAG",
   "S11_DISCOVERED", "S13_HHHL_DAY", "S16_HHHL_WICK_1H",
 ];
 const SHORT = {

--- a/goldpetal/test_desk.py
+++ b/goldpetal/test_desk.py
@@ -44,6 +44,8 @@ def test_station_is_the_operator_page() -> None:
     assert "S16_HHHL_WICK_1H" in html
     paper = html.split("const PAPER_BOOKS")[1].split("];")[0]
     assert "S16_HHHL_WICK_1H" in paper
+    assert "S13_HHHL_DAY" in paper
+    assert "S4_OVERNIGHT" not in paper
     assert "S12_HHHL30" not in paper
     assert "S14_WICK30_STRICT" not in paper
     assert "S15_WICK30_NOWICK" not in paper

--- a/goldpetal/test_live_readiness.py
+++ b/goldpetal/test_live_readiness.py
@@ -166,15 +166,18 @@ def test_apply_panel_enables_slim() -> None:
     try:
         env = Path(td.name) / ".env"
         env.write_text("ENABLE_S4=true\nENABLE_S9=true\nSECRET=keep\n", encoding="utf-8")
-        res = apply_panel_enables(["S4_OVERNIGHT", "S16_HHHL_WICK_1H"], path=env)
+        res = apply_panel_enables(["S4_OVERNIGHT", "S13_HHHL_DAY", "S16_HHHL_WICK_1H"], path=env)
         assert res["ok"] is True
         text = env.read_text(encoding="utf-8")
-        assert "ENABLE_S4=true" in text
+        assert "ENABLE_S4=false" in text
+        assert "ENABLE_S13=true" in text
         assert "ENABLE_S16=true" in text
         assert "ENABLE_S9=false" in text
         assert "ENABLE_S5=false" in text
         assert "SECRET=keep" in text
         assert "S16_HHHL_WICK_1H" in res["enabled"]
+        assert "S13_HHHL_DAY" in res["enabled"]
+        assert "S4_OVERNIGHT" not in res["enabled"]
     finally:
         td.cleanup()
 
@@ -215,6 +218,8 @@ def test_desk_snapshot_skips_checklist() -> None:
     assert "steps" not in snap
     assert "S16_HHHL_WICK_1H" in snap["enables"]
     assert any(b["strategy"] == "S16_HHHL_WICK_1H" for b in snap["books"])
+    assert "S4_OVERNIGHT" not in snap["enables"]
+    assert not any(b["strategy"] == "S4_OVERNIGHT" for b in snap["books"])
     assert "S14_WICK30_STRICT" not in snap["enables"]
     assert snap["would_place_real_orders"] is False
 

--- a/goldpetal/test_s16_hhhl_wick.py
+++ b/goldpetal/test_s16_hhhl_wick.py
@@ -155,6 +155,8 @@ def test_walk_marks_flip() -> None:
 def test_paper_wired_1h_not_s17() -> None:
     assert "S16_HHHL_WICK_1H" in ALL_STRATEGY_NAMES
     assert "S16_HHHL_WICK_1H" in SLIM_PAPER_STRATEGIES
+    assert "S13_HHHL_DAY" in SLIM_PAPER_STRATEGIES
+    assert "S4_OVERNIGHT" not in SLIM_PAPER_STRATEGIES
     assert "S12_HHHL30" not in SLIM_PAPER_STRATEGIES
     assert "S14_WICK30_STRICT" not in SLIM_PAPER_STRATEGIES
     assert "S15_WICK30_NOWICK" not in SLIM_PAPER_STRATEGIES


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
S4 daily HH/LL lost the Angel/ticks backtest to **S13** (S16 on the day candle — the ~₹76.6k after-tax row). S4 stays off and is **removed from the station book list**.

Paper books on the desk: **S5, S8, S11, S13, S16**.

- Save strategies cannot set `ENABLE_S4=true`
- S13 is unchanged: last 15m confirm, hold until opposite, FLIP, skip EOD flatten, flatten on Gold Petal rollover
- S16 stays the 1h intraday book
- Swing/backtest S4 code stays in the repo; overnight ML stays research-only
- `DRY_RUN` stays true

After pull: desk restart only (`./scripts/run_desk_vm.sh --restart`), then Cmd+Shift+R. Bot restart is not required if `ENABLE_S4` is already false.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e92370bb-ed6a-433d-8b83-fe612227a4b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e92370bb-ed6a-433d-8b83-fe612227a4b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

