### PR TITLE
Backtest S16 with total buy vs sell quantity

### DIFF
--- a/goldpetal/backtest_s16_tbq_tsq.py
+++ b/goldpetal/backtest_s16_tbq_tsq.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Backtest S16 vs total_buy / total_sell quantity on ticks.db.
+
+Research only. Does not change paper S16. Angel 1h candles have no TBQ/TSQ.
+
+  cd ~/goldpetal-repo/goldpetal
+  ./venv/bin/python backtest_s16_tbq_tsq.py --db data/ticks.db --lots 100 --session --fees
+  ./venv/bin/python backtest_s16_tbq_tsq.py --db data/ticks.db --tf 1h --lots 100 --session --fees
+
+Default: 1h (paper S16 tf) and 30m, wick gap 0 like paper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Any
+
+from backtest_hhhl_candles import TIMEFRAMES, make_charge_cfg, write_outputs
+from backtest_wick_candles import print_wick_summary
+from mtf_bars import build_rich_bars, load_tick_rows
+from s16_hhhl_wick import simulate_s16, walk_candles
+from s16_tbq_tsq import VARIANTS, candles_from_rich, variant_decide
+
+DEFAULT_TFS = "1h,30m"
+DEFAULT_VARIANTS = ",".join(VARIANTS)
+
+
+def _parse_tfs(raw: str) -> list[tuple[str, int]]:
+    by = {n: m for n, m in TIMEFRAMES}
+    out: list[tuple[str, int]] = []
+    for name in (x.strip().lower() for x in raw.split(",") if x.strip()):
+        if name not in by:
+            raise SystemExit(f"unknown tf {name!r}. have: {', '.join(by)}")
+        out.append((name, by[name]))
+    if not out:
+        raise SystemExit("no timeframes")
+    return out
+
+
+def _parse_variants(raw: str) -> list[str]:
+    out: list[str] = []
+    for name in (x.strip() for x in raw.split(",") if x.strip()):
+        if name not in VARIANTS:
+            raise SystemExit(f"unknown variant {name!r}. have: {', '.join(VARIANTS)}")
+        out.append(name)
+    if not out:
+        raise SystemExit("no variants")
+    return out
+
+
+def write_walk(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "time",
+        "open",
+        "high",
+        "low",
+        "close",
+        "tbq_open",
+        "tbq_close",
+        "tsq_open",
+        "tsq_close",
+        "d_tbq",
+        "d_tsq",
+        "rule",
+        "side",
+        "action",
+        "pos_before",
+        "pos_after",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        w.writerows(rows)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="S16 vs TBQ/TSQ backtest (ticks only)")
+    ap.add_argument("--db", default="data/ticks.db")
+    ap.add_argument("--tf", default=DEFAULT_TFS)
+    ap.add_argument("--variants", default=DEFAULT_VARIANTS)
+    ap.add_argument("--lots", type=float, default=100.0)
+    ap.add_argument("--session", action=argparse.BooleanOptionalAction, default=True)
+    ap.add_argument("--fees", action=argparse.BooleanOptionalAction, default=True)
+    ap.add_argument("--min-wick-gap", type=float, default=0.0)
+    ap.add_argument("--out-dir", default="data/backtests/s16_tbq_tsq")
+    args = ap.parse_args()
+
+    db = Path(args.db)
+    if not db.is_file():
+        raise SystemExit(f"missing {db}")
+    rows = load_tick_rows(db)
+    if len(rows) < 50:
+        raise SystemExit(f"{db} has {len(rows)} ticks — need the VM ticks.db")
+
+    tfs = _parse_tfs(args.tf)
+    names = _parse_variants(args.variants)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print()
+    print("S16 + total_buy_quantity / total_sell_quantity  (research, not paper)")
+    print(f"  db={db} ticks={len(rows)} lots={args.lots:g} session={args.session} fees={args.fees}")
+    print(f"  wick_gap={args.min_wick_gap:g} (paper S16 uses 0)")
+    for key, (label, _fn) in VARIANTS.items():
+        if key in names:
+            print(f"  {key:16} {label}")
+    print()
+
+    results = []
+    baseline: dict[str, float] = {}
+    for tf_name, minutes in tfs:
+        bars = build_rich_bars(rows, tf_name, minutes)
+        candles = candles_from_rich(bars)
+        if len(candles) < 3:
+            print(f"skip {tf_name}: {len(candles)} bars")
+            continue
+        for name in names:
+            decide = variant_decide(name, min_wick_gap=args.min_wick_gap)
+            res = simulate_s16(
+                candles,
+                tf=f"{tf_name}:{name}",
+                lots=args.lots,
+                fees=args.fees,
+                session_filter=args.session,
+                min_wick_gap=args.min_wick_gap,
+                decide=decide,
+            )
+            results.append(res)
+            if name == "s16":
+                baseline[tf_name] = float(res.after_tax_pnl_inr)
+            walk = walk_candles(candles, min_wick_gap=args.min_wick_gap, decide=decide)
+            for row, c in zip(walk, candles[1:]):
+                row["tbq_open"] = c.tbq_open
+                row["tbq_close"] = c.tbq_close
+                row["tsq_open"] = c.tsq_open
+                row["tsq_close"] = c.tsq_close
+                row["d_tbq"] = c.d_tbq
+                row["d_tsq"] = c.d_tsq
+            write_walk(out_dir / f"walk_{tf_name}_{name}.csv", walk)
+
+    write_outputs(results, out_dir)
+
+    print_wick_summary(results, title="S16 vs TBQ/TSQ")
+    if baseline and results:
+        print("Δ after-tax vs paper s16 on the same tf:")
+        print(f"  {'row':>22}  {'pnl_₹':>10}  {'Δ vs s16':>10}")
+        print("  " + "-" * 46)
+        for r in results:
+            tf, _, var = r.tf.partition(":")
+            base = baseline.get(tf)
+            delta = "" if base is None or var == "s16" else f"{r.after_tax_pnl_inr - base:+.1f}"
+            print(f"  {r.tf:>22}  {r.after_tax_pnl_inr:10.1f}  {delta:>10}")
+        print()
+    print(f"wrote {out_dir}")
+    print("Do not paper a qty variant until a 100-lot + fees row beats s16.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goldpetal/s16_tbq_tsq.py
+++ b/goldpetal/s16_tbq_tsq.py
@@ -1,0 +1,167 @@
+"""Research: S16 1h formula plus total_buy_quantity / total_sell_quantity.
+
+Paper S16 is unchanged (OHLC only). These decides are for ticks.db backtests.
+
+On each finished bar, ticks already store Angel ``total_buy_quantity`` (TBQ)
+and ``total_sell_quantity`` (TSQ) at open and close of the bar.
+
+  qty_close  TBQ>TSQ at bar close → buy-side book; TSQ>TBQ → sell-side
+  qty_flow   ΔTBQ vs ΔTSQ during the bar (who added more size this hour)
+
+Variants (FLIP, fill at close, same session flatten as S16):
+
+  s16           current paper: C>prev HH/LL, C<prev wick, C=prev skip
+  s16_qty_agree S16 side only if qty_close agrees (long needs TBQ>TSQ)
+  s16_qty_flow  S16 side only if qty_flow agrees (long needs ΔTBQ>ΔTSQ)
+  s16_qty_down  C>prev still HH/LL; C<prev uses qty_close instead of wick
+  qty_close     ignore OHLC S16; TBQ vs TSQ at close only
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from backtest_hhhl_candles import Candle
+from mtf_bars import RichBar
+from s16_hhhl_wick import s16_bar_decision
+
+DecideFn = Callable[[Candle, Candle], tuple[str | None, str]]
+
+
+@dataclass
+class QtyCandle(Candle):
+    tbq_open: float = 0.0
+    tbq_close: float = 0.0
+    tsq_open: float = 0.0
+    tsq_close: float = 0.0
+
+    @property
+    def d_tbq(self) -> float:
+        return float(self.tbq_close) - float(self.tbq_open)
+
+    @property
+    def d_tsq(self) -> float:
+        return float(self.tsq_close) - float(self.tsq_open)
+
+
+def candles_from_rich(bars: list[RichBar]) -> list[QtyCandle]:
+    out: list[QtyCandle] = []
+    for b in bars:
+        out.append(
+            QtyCandle(
+                time=str(b.time),
+                open=float(b.open),
+                high=float(b.high),
+                low=float(b.low),
+                close=float(b.close),
+                tbq_open=float(b.tbq_open or 0.0),
+                tbq_close=float(b.tbq_close or 0.0),
+                tsq_open=float(b.tsq_open or 0.0),
+                tsq_close=float(b.tsq_close or 0.0),
+            )
+        )
+    return out
+
+
+def _qty(cur: Candle) -> QtyCandle | None:
+    if isinstance(cur, QtyCandle):
+        return cur
+    return None
+
+
+def _close_side(q: QtyCandle) -> tuple[str | None, str]:
+    if q.tbq_close > q.tsq_close:
+        return "long", f"TBQ>TSQ {q.tbq_close:.0f}>{q.tsq_close:.0f}"
+    if q.tsq_close > q.tbq_close:
+        return "short", f"TSQ>TBQ {q.tsq_close:.0f}>{q.tbq_close:.0f}"
+    return None, f"TBQ=TSQ {q.tbq_close:.0f}"
+
+
+def _flow_side(q: QtyCandle) -> tuple[str | None, str]:
+    if q.d_tbq > q.d_tsq:
+        return "long", f"ΔTBQ>ΔTSQ {q.d_tbq:.0f}>{q.d_tsq:.0f}"
+    if q.d_tsq > q.d_tbq:
+        return "short", f"ΔTSQ>ΔTBQ {q.d_tsq:.0f}>{q.d_tbq:.0f}"
+    return None, f"ΔTBQ=ΔTSQ {q.d_tbq:.0f}"
+
+
+def s16_plain(prev: Candle, cur: Candle, *, min_wick_gap: float = 0.0) -> tuple[str | None, str]:
+    return s16_bar_decision(prev, cur, min_wick_gap=min_wick_gap)
+
+
+def s16_qty_agree(
+    prev: Candle, cur: Candle, *, min_wick_gap: float = 0.0
+) -> tuple[str | None, str]:
+    side, why = s16_bar_decision(prev, cur, min_wick_gap=min_wick_gap)
+    q = _qty(cur)
+    if side is None:
+        return None, why
+    if q is None:
+        return None, why + " | no TBQ/TSQ"
+    close, qwhy = _close_side(q)
+    if close == side:
+        return side, f"{why} | {qwhy}"
+    return None, f"{why} | qty disagree {qwhy}"
+
+
+def s16_qty_flow(
+    prev: Candle, cur: Candle, *, min_wick_gap: float = 0.0
+) -> tuple[str | None, str]:
+    side, why = s16_bar_decision(prev, cur, min_wick_gap=min_wick_gap)
+    q = _qty(cur)
+    if side is None:
+        return None, why
+    if q is None:
+        return None, why + " | no TBQ/TSQ"
+    flow, qwhy = _flow_side(q)
+    if flow == side:
+        return side, f"{why} | {qwhy}"
+    return None, f"{why} | flow disagree {qwhy}"
+
+
+def s16_qty_down(
+    prev: Candle, cur: Candle, *, min_wick_gap: float = 0.0
+) -> tuple[str | None, str]:
+    """Up-close still HH/LL. Down-close uses TBQ vs TSQ instead of wick."""
+    del min_wick_gap
+    if cur.close > prev.close:
+        return s16_bar_decision(prev, cur, min_wick_gap=0.0)
+    if cur.close < prev.close:
+        q = _qty(cur)
+        if q is None:
+            return None, "C<prev → no TBQ/TSQ"
+        side, qwhy = _close_side(q)
+        if side is None:
+            return None, f"C<prev → {qwhy}"
+        return side, f"C<prev → {qwhy}"
+    return None, "C=prev skip"
+
+
+def qty_close_only(prev: Candle, cur: Candle, *, min_wick_gap: float = 0.0) -> tuple[str | None, str]:
+    del prev, min_wick_gap
+    q = _qty(cur)
+    if q is None:
+        return None, "no TBQ/TSQ"
+    return _close_side(q)
+
+
+VARIANTS: dict[str, tuple[str, DecideFn]] = {
+    "s16": ("paper S16 (OHLC only)", s16_plain),
+    "s16_qty_agree": ("S16 + TBQ/TSQ at close must agree", s16_qty_agree),
+    "s16_qty_flow": ("S16 + ΔTBQ vs ΔTSQ in the bar must agree", s16_qty_flow),
+    "s16_qty_down": ("C>prev HH/LL; C<prev TBQ vs TSQ (no wick)", s16_qty_down),
+    "qty_close": ("TBQ vs TSQ at close only (no S16 OHLC)", qty_close_only),
+}
+
+
+def variant_decide(name: str, *, min_wick_gap: float = 0.0) -> DecideFn:
+    if name not in VARIANTS:
+        raise ValueError(f"unknown variant {name!r}. have: {', '.join(VARIANTS)}")
+    _label, fn = VARIANTS[name]
+
+    def _wrapped(prev: Candle, cur: Candle) -> tuple[str | None, str]:
+        return fn(prev, cur, min_wick_gap=min_wick_gap)
+
+    _wrapped.__name__ = name
+    return _wrapped

--- a/goldpetal/test_s16_tbq_tsq.py
+++ b/goldpetal/test_s16_tbq_tsq.py
@@ -1,0 +1,174 @@
+"""S16 + TBQ/TSQ research decides (backtest only, not paper)."""
+
+from __future__ import annotations
+
+from backtest_hhhl_candles import Candle
+from s16_hhhl_wick import simulate_s16
+from s16_tbq_tsq import QtyCandle, s16_qty_agree, s16_qty_down, s16_qty_flow, qty_close_only
+
+
+def _ohlc(t: str, o: float, h: float, l: float, c: float) -> Candle:
+    return Candle(t, o, h, l, c)
+
+
+def _q(
+    t: str,
+    o: float,
+    h: float,
+    l: float,
+    c: float,
+    *,
+    tbq_o: float,
+    tbq_c: float,
+    tsq_o: float,
+    tsq_c: float,
+) -> QtyCandle:
+    return QtyCandle(t, o, h, l, c, tbq_o, tbq_c, tsq_o, tsq_c)
+
+
+PREV = _q("2026-08-17 10:00:00", 100.0, 105.0, 99.0, 104.0, tbq_o=100, tbq_c=110, tsq_o=90, tsq_c=95)
+
+
+def test_qty_agree_blocks_long_when_sell_book_is_bigger() -> None:
+    cur = _q(
+        "2026-08-17 11:00:00",
+        100.0,
+        120.0,
+        100.0,
+        110.0,
+        tbq_o=100,
+        tbq_c=80,
+        tsq_o=90,
+        tsq_c=200,
+    )
+    side, why = s16_qty_agree(PREV, cur, min_wick_gap=0)
+    assert side is None
+    assert "qty disagree" in why
+
+
+def test_qty_agree_keeps_long_when_buy_book_is_bigger() -> None:
+    cur = _q(
+        "2026-08-17 11:00:00",
+        100.0,
+        120.0,
+        100.0,
+        110.0,
+        tbq_o=100,
+        tbq_c=250,
+        tsq_o=90,
+        tsq_c=80,
+    )
+    side, why = s16_qty_agree(PREV, cur, min_wick_gap=0)
+    assert side == "long"
+    assert "TBQ>TSQ" in why
+
+
+def test_qty_flow_uses_bar_delta_not_close_level() -> None:
+    # Close still TBQ>TSQ, but this hour sellers added more.
+    cur = _q(
+        "2026-08-17 11:00:00",
+        100.0,
+        120.0,
+        100.0,
+        110.0,
+        tbq_o=200,
+        tbq_c=210,
+        tsq_o=50,
+        tsq_c=180,
+    )
+    side, why = s16_qty_flow(PREV, cur, min_wick_gap=0)
+    assert side is None
+    assert "flow disagree" in why
+    assert cur.d_tsq > cur.d_tbq
+
+
+def test_qty_down_replaces_wick_on_down_close() -> None:
+    # Down close with long lower wick would be S16 LONG; TBQ<TSQ → SHORT.
+    cur = _q(
+        "2026-08-17 11:00:00",
+        103.0,
+        104.0,
+        80.0,
+        100.0,
+        tbq_o=100,
+        tbq_c=90,
+        tsq_o=100,
+        tsq_c=140,
+    )
+    assert cur.close < PREV.close
+    side, why = s16_qty_down(PREV, cur)
+    assert side == "short"
+    assert "C<prev" in why
+    assert "TSQ>TBQ" in why
+
+
+def test_qty_close_only_ignores_ohlc() -> None:
+    cur = _q(
+        "2026-08-17 11:00:00",
+        104.0,
+        105.0,
+        103.0,
+        104.0,
+        tbq_o=1,
+        tbq_c=9,
+        tsq_o=1,
+        tsq_c=2,
+    )
+    side, _ = qty_close_only(PREV, cur)
+    assert side == "long"
+
+
+def test_qty_agree_without_qty_fields_skips() -> None:
+    cur = _ohlc("2026-08-17 11:00:00", 100.0, 120.0, 100.0, 110.0)
+    side, why = s16_qty_agree(PREV, cur)
+    assert side is None
+    assert "no TBQ/TSQ" in why
+
+
+def test_simulate_qty_agree_does_not_enter_disagree_bar() -> None:
+    candles = [
+        PREV,
+        _q(
+            "2026-08-17 11:00:00",
+            100.0,
+            120.0,
+            100.0,
+            110.0,
+            tbq_o=10,
+            tbq_c=10,
+            tsq_o=50,
+            tsq_c=80,
+        ),
+        _q(
+            "2026-08-17 12:00:00",
+            110.0,
+            130.0,
+            109.0,
+            120.0,
+            tbq_o=80,
+            tbq_c=200,
+            tsq_o=80,
+            tsq_c=50,
+        ),
+    ]
+    res = simulate_s16(
+        candles,
+        tf="1h:s16_qty_agree",
+        lots=1,
+        fees=False,
+        session_filter=False,
+        min_wick_gap=0,
+        decide=lambda a, b: s16_qty_agree(a, b, min_wick_gap=0),
+    )
+    assert res.n_trades >= 1
+
+
+if __name__ == "__main__":
+    test_qty_agree_blocks_long_when_sell_book_is_bigger()
+    test_qty_agree_keeps_long_when_buy_book_is_bigger()
+    test_qty_flow_uses_bar_delta_not_close_level()
+    test_qty_down_replaces_wick_on_down_close()
+    test_qty_close_only_ignores_ohlc()
+    test_qty_agree_without_qty_fields_skips()
+    test_simulate_qty_agree_does_not_enter_disagree_bar()
+    print("all s16 tbq/tsq tests passed")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Research only. Paper S16 is unchanged (1h OHLC: up-close HH/LL, down-close wick).

ticks.db 1h bars already have Angel `total_buy_quantity` / `total_sell_quantity` at bar open and close. This backtest compares, 100 lots + fees + session:

| row | rule |
|---|---|
| `s16` | current paper formula |
| `s16_qty_agree` | S16 side only if TBQ vs TSQ at **close** agrees |
| `s16_qty_flow` | S16 side only if ΔTBQ vs ΔTSQ **in the bar** agrees |
| `s16_qty_down` | up-close still HH/LL; down-close uses TBQ vs TSQ instead of wick |
| `qty_close` | TBQ vs TSQ at close only (no S16 OHLC) |

Angel 1h candles have no TBQ/TSQ — run on the VM `ticks.db`. Do not paper a qty row until it beats `s16` after tax. `DRY_RUN` stays true. Do not restart the bot for this.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e92370bb-ed6a-433d-8b83-fe612227a4b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e92370bb-ed6a-433d-8b83-fe612227a4b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

