### PR TITLE
S16 waits for a same-session 1h side, not the first hour timer

### DIFF
--- a/goldpetal/s16_hhhl_wick.py
+++ b/goldpetal/s16_hhhl_wick.py
@@ -267,6 +267,12 @@ def simulate_s16(
             continue
         if session_filter and not sess_ok:
             continue
+        if session_filter:
+            prev_sess = in_session(
+                prev, open_hhmm=market_open, close_hhmm=market_close
+            )
+            if (not prev_sess) or prev.time[:10] != cur.time[:10]:
+                continue
 
         want, _why = decide_fn(prev, cur)
         want_long = want == "long"

--- a/goldpetal/strategy_hhhl_day.py
+++ b/goldpetal/strategy_hhhl_day.py
@@ -288,6 +288,9 @@ class HhhlDayOvernightStrategy:
                     elif self.prev_day.date == prev_date:
                         self.prev_day.high = max(self.prev_day.high, prev_bar.high)
                         self.prev_day.low = min(self.prev_day.low, prev_bar.low)
+                        # State json only saves when H/L move, so close can be
+                        # an old print. Last tick of that day is the real close.
+                        self.prev_day.close = prev_bar.close
             current = self._ohlc_from_sql(db, today)
             if current is not None:
                 self._merge_forming_day(current)
@@ -339,10 +342,20 @@ class HhhlDayOvernightStrategy:
         """Back-compat alias — confirm window is used for both entry and exit."""
         return self._in_confirm_window(now)
 
+    def _seal_prev_day(self, bar: DayOhlc) -> None:
+        """Move a finished day into prev. Same-date JSON must not clobber SQL close."""
+        if self.prev_day is None or self.prev_day.date < bar.date:
+            self.prev_day = bar
+            return
+        if self.prev_day.date != bar.date:
+            return
+        self.prev_day.high = max(self.prev_day.high, bar.high)
+        self.prev_day.low = min(self.prev_day.low, bar.low)
+
     def _roll_day(self, today: str, px: float) -> None:
         """On calendar day change, seal yesterday as prev_day and start new bar."""
         if self._day is not None and self._day.date != today:
-            self.prev_day = self._day
+            self._seal_prev_day(self._day)
             self._day = DayOhlc(date=today, open=px, high=px, low=px, close=px)
             self._acted_today = False
             self._save_state()
@@ -457,8 +470,8 @@ class HhhlDayOvernightStrategy:
         return self._flip_to(side, px, today, why, _as_candle(day))
 
     def _watch_skip(self) -> None:
-        if not (self._day and self.prev_day):
-            self.last_skip = "outside_confirm_window"
+        if self._day is None or self.prev_day is None:
+            self.last_skip = "need_prev_day"
             return
         if self._formula() == "hhhl":
             if self._day.high > self.prev_day.high:

--- a/goldpetal/strategy_s16.py
+++ b/goldpetal/strategy_s16.py
@@ -16,8 +16,10 @@ No range skip. No bald-body. No open=high/low (that is S14).
 Intraday only: the first finished session 1h is stored as prev (no trade).
 The next finished session 1h can BUY/SHORT only if this formula picks a
 side vs that same-session prev. Never use yesterday's last hour or a
-preopen hour as prev. Flatten at MARKET_CLOSE (and leftover at next
-MARKET_OPEN). Never overnight.
+preopen hour as prev. A restart after that hour already finished still
+applies the last closed session 1h vs the hour before it (fill at that
+bar's close), unless a signal was already recorded at/after that close.
+Flatten at MARKET_CLOSE (and leftover at next MARKET_OPEN). Never overnight.
 Not live-unlocked. Paper 100 lots ≠ live.
 """
 
@@ -66,6 +68,9 @@ class S16HhhlWickStrategy:
         self._bar_o = self._bar_h = self._bar_l = self._bar_c = None
         self._bar_n = 0
         self._prev: Candle | None = None
+        self._catchup_prev: Candle | None = None
+        self._catchup_cur: Candle | None = None
+        self._last_signal_at: datetime | None = None
         if seed:
             self.seed_from_ticks()
 
@@ -227,11 +232,12 @@ class S16HhhlWickStrategy:
             row = last[0]
             action = str(row["action"] or "").upper()
             pos = str(row["position_after"] or "").lower()
+            tl = str(row["time_label"] or "")
+            self._last_signal_at = _parse_ts(tl)
             if action in {"BUY", "SHORT"} and pos in {"long", "short"}:
                 self.position = pos  # type: ignore[assignment]
                 cmp = row["cmp"]
                 self.entry_price = float(cmp) if cmp is not None else None
-                tl = str(row["time_label"] or "")
                 self.entry_date = tl[:10] if tl else None
             elif action == "CLOSE" or pos == "flat":
                 self.position = "flat"
@@ -240,18 +246,66 @@ class S16HhhlWickStrategy:
         except Exception:
             return
 
+    def _session_candle(
+        self,
+        key: datetime,
+        ohlc: tuple[float, float, float, float, int] | None,
+        now: datetime,
+    ) -> Candle | None:
+        if ohlc is None:
+            return None
+        o, h, l, c, _n = ohlc
+        cand = Candle(
+            time=key.strftime("%Y-%m-%d %H:%M:%S"),
+            open=o,
+            high=h,
+            low=l,
+            close=c,
+        )
+        if cand.time[:10] != now.strftime("%Y-%m-%d"):
+            return None
+        if not self._bar_started_in_session(cand):
+            return None
+        return cand
+
+    def _already_decided_close(self, closed_key: datetime) -> bool:
+        if self._last_signal_at is None:
+            return False
+        close_at = closed_key + timedelta(minutes=max(1, self.cfg.bar_minutes))
+        return self._last_signal_at >= close_at
+
+    def _run_catchup(self, now: datetime) -> SignalResult | None:
+        """Apply the last finished session 1h if restart missed that close tick."""
+        cur = self._catchup_cur
+        prev = self._catchup_prev
+        self._catchup_cur = None
+        self._catchup_prev = None
+        if cur is None or prev is None or not self._in_session(now):
+            return None
+        saved = self._prev
+        self._prev = prev
+        try:
+            result = self._decide_closed(cur)
+        finally:
+            self._prev = saved if saved is not None else cur
+        if result is not None:
+            result.reason = f"{result.reason} restart catch-up"
+        return result
+
     def seed_from_ticks(
         self, db_path: Path | None = None, *, now: datetime | None = None
     ) -> None:
-        """Hydrate the previous closed 1h bar and the in-progress 1h OHLC."""
+        """Hydrate last closed 1h, catch up that close if restart missed it."""
         try:
             db = db_path or (Path(__file__).resolve().parent / "data" / "ticks.db")
             if not db.exists():
                 return
             self._seed_position_from_signals(db)
             now = (now or datetime.now(IST)).astimezone(IST)
+            step = timedelta(minutes=max(1, self.cfg.bar_minutes))
             cur_key = self._floor_bar(now)
-            prev_key = cur_key - timedelta(minutes=max(1, self.cfg.bar_minutes))
+            closed_key = cur_key - step
+            prev_key = closed_key - step
             start = prev_key.strftime("%Y-%m-%dT%H:%M:%S")
             con = sqlite3.connect(str(db))
             try:
@@ -263,22 +317,18 @@ class S16HhhlWickStrategy:
                 ).fetchall()
             finally:
                 con.close()
-            prev_ohlc = self._ohlc_from_rows(rows, prev_key)
+            prev_c = self._session_candle(
+                prev_key, self._ohlc_from_rows(rows, prev_key), now
+            )
+            closed_c = self._session_candle(
+                closed_key, self._ohlc_from_rows(rows, closed_key), now
+            )
             cur_ohlc = self._ohlc_from_rows(rows, cur_key)
-            if prev_ohlc is not None:
-                o, h, l, c, _n = prev_ohlc
-                cand = Candle(
-                    time=prev_key.strftime("%Y-%m-%d %H:%M:%S"),
-                    open=o,
-                    high=h,
-                    low=l,
-                    close=c,
-                )
-                if (
-                    cand.time[:10] == now.strftime("%Y-%m-%d")
-                    and self._bar_started_in_session(cand)
-                ):
-                    self._prev = cand
+            if closed_c is not None:
+                self._prev = closed_c
+                if prev_c is not None and not self._already_decided_close(closed_key):
+                    self._catchup_prev = prev_c
+                    self._catchup_cur = closed_c
             if cur_ohlc is None:
                 return
             o, h, l, c, n = cur_ohlc
@@ -321,11 +371,17 @@ class S16HhhlWickStrategy:
         key = self._floor_bar(now)
         px = float(ltp)
         flatten_why = self._session_flatten_why(now)
+        had_catchup = self._catchup_cur is not None
+        catchup = None if flatten_why else self._run_catchup(now)
 
         if self._bar_key is None:
             self._reset_bar(key, px)
             if flatten_why:
                 return self._flatten(px, flatten_why)
+            if catchup is not None:
+                return catchup
+            if had_catchup:
+                return None
             self.last_skip = "waiting_1h_close"
             return None
 
@@ -342,7 +398,7 @@ class S16HhhlWickStrategy:
             self._reset_bar(key, px)
             if flatten_why:
                 return self._flatten(px, flatten_why)
-            return result
+            return result if result is not None else catchup
 
         assert self._bar_h is not None and self._bar_l is not None
         self._bar_h = max(self._bar_h, px)
@@ -351,6 +407,10 @@ class S16HhhlWickStrategy:
         self._bar_n += 1
         if flatten_why:
             return self._flatten(px, flatten_why)
+        if catchup is not None:
+            return catchup
+        if had_catchup:
+            return None
         self.last_skip = "waiting_1h_close"
         return None
 

--- a/goldpetal/strategy_s16.py
+++ b/goldpetal/strategy_s16.py
@@ -13,8 +13,11 @@ on that **same** closed bar vs the previous closed bar:
 
 FLIP if already the other side. Fill at this bar's close.
 No range skip. No bald-body. No open=high/low (that is S14).
-Intraday only: first fill is the first finished 1h of the session;
-flatten at MARKET_CLOSE (and leftover at next MARKET_OPEN). Never overnight.
+Intraday only: the first finished session 1h is stored as prev (no trade).
+The next finished session 1h can BUY/SHORT only if this formula picks a
+side vs that same-session prev. Never use yesterday's last hour or a
+preopen hour as prev. Flatten at MARKET_CLOSE (and leftover at next
+MARKET_OPEN). Never overnight.
 Not live-unlocked. Paper 100 lots ≠ live.
 """
 
@@ -127,6 +130,22 @@ class S16HhhlWickStrategy:
         t = dt.hour * 60 + dt.minute
         return (oh * 60 + om) <= t < (ch * 60 + cm)
 
+    def _same_session_prev(self, prev: Candle, cur: Candle) -> bool:
+        """Prev must be a session 1h from the same calendar day as cur."""
+        if not self._bar_started_in_session(prev):
+            return False
+        if not self._bar_started_in_session(cur):
+            return False
+        prev_day = prev.time[:10]
+        return bool(prev_day) and prev_day == cur.time[:10]
+
+    def _drop_stale_prev(self, now: datetime) -> None:
+        if self._prev is None:
+            return
+        today = now.strftime("%Y-%m-%d")
+        if self._prev.time[:10] != today or not self._bar_started_in_session(self._prev):
+            self._prev = None
+
     def _session_flatten_why(self, now: datetime) -> str | None:
         if self.position == "flat":
             return None
@@ -170,7 +189,10 @@ class S16HhhlWickStrategy:
             and self._bar_started_in_session(closed)
         ):
             result = self._decide_closed(closed)
-        if self._bar_started_in_session(closed):
+        if (
+            self._bar_started_in_session(closed)
+            and closed.time[:10] == now.strftime("%Y-%m-%d")
+        ):
             self._prev = closed
         return result
 
@@ -245,13 +267,18 @@ class S16HhhlWickStrategy:
             cur_ohlc = self._ohlc_from_rows(rows, cur_key)
             if prev_ohlc is not None:
                 o, h, l, c, _n = prev_ohlc
-                self._prev = Candle(
+                cand = Candle(
                     time=prev_key.strftime("%Y-%m-%d %H:%M:%S"),
                     open=o,
                     high=h,
                     low=l,
                     close=c,
                 )
+                if (
+                    cand.time[:10] == now.strftime("%Y-%m-%d")
+                    and self._bar_started_in_session(cand)
+                ):
+                    self._prev = cand
             if cur_ohlc is None:
                 return
             o, h, l, c, n = cur_ohlc
@@ -290,6 +317,7 @@ class S16HhhlWickStrategy:
     ) -> SignalResult | None:
         del message
         now = now.astimezone(IST)
+        self._drop_stale_prev(now)
         key = self._floor_bar(now)
         px = float(ltp)
         flatten_why = self._session_flatten_why(now)
@@ -304,7 +332,12 @@ class S16HhhlWickStrategy:
         if key != self._bar_key:
             closed = self._closed_candle()
             result = None if flatten_why else self._maybe_decide_closed(closed, now)
-            if flatten_why and closed is not None and self._bar_started_in_session(closed):
+            if (
+                flatten_why
+                and closed is not None
+                and self._bar_started_in_session(closed)
+                and closed.time[:10] == now.strftime("%Y-%m-%d")
+            ):
                 self._prev = closed
             self._reset_bar(key, px)
             if flatten_why:
@@ -338,7 +371,7 @@ class S16HhhlWickStrategy:
         if cur is None:
             self.last_skip = "no_closed_bar"
             return None
-        if self._prev is None:
+        if self._prev is None or not self._same_session_prev(self._prev, cur):
             self.last_skip = "need_prev_1h"
             return None
         side, why = s16_bar_decision(

--- a/goldpetal/test_s16_hhhl_wick.py
+++ b/goldpetal/test_s16_hhhl_wick.py
@@ -152,6 +152,36 @@ def test_walk_marks_flip() -> None:
     assert rows[1]["action"] == "FLIP"
 
 
+def test_session_filter_skips_first_hour_vs_prior_day() -> None:
+    candles = [
+        _c("2026-08-17 23:00:00", 90.0, 140.0, 80.0, 80.0),
+        _c("2026-08-18 09:00:00", 100.0, 130.0, 100.0, 120.0),
+        _c("2026-08-18 10:00:00", 120.0, 140.0, 119.0, 130.0),
+        _c("2026-08-18 11:00:00", 130.0, 131.0, 129.0, 130.5),
+    ]
+    r = simulate_s16(
+        candles, tf="toy:sess", lots=1, fees=False, session_filter=True, min_wick_gap=0
+    )
+    assert r.n_trades == 1
+    assert r.trades[0].entry_time == "2026-08-18 10:00:00"
+    assert r.trades[0].entry_px == 130.0
+
+
+def test_session_filter_skips_first_hour_vs_preopen() -> None:
+    candles = [
+        _c("2026-08-17 08:00:00", 90.0, 140.0, 80.0, 80.0),
+        _c("2026-08-17 09:00:00", 100.0, 130.0, 100.0, 120.0),
+        _c("2026-08-17 10:00:00", 120.0, 140.0, 119.0, 130.0),
+        _c("2026-08-17 11:00:00", 130.0, 131.0, 129.0, 130.5),
+    ]
+    r = simulate_s16(
+        candles, tf="toy:pre", lots=1, fees=False, session_filter=True, min_wick_gap=0
+    )
+    assert r.n_trades == 1
+    assert r.trades[0].entry_time == "2026-08-17 10:00:00"
+    assert r.trades[0].entry_px == 130.0
+
+
 def test_paper_wired_1h_not_s17() -> None:
     assert "S16_HHHL_WICK_1H" in ALL_STRATEGY_NAMES
     assert "S16_HHHL_WICK_1H" in SLIM_PAPER_STRATEGIES
@@ -213,6 +243,8 @@ if __name__ == "__main__":
     test_enter_then_flip()
     test_skip_bar_holds_open_trade()
     test_walk_marks_flip()
+    test_session_filter_skips_first_hour_vs_prior_day()
+    test_session_filter_skips_first_hour_vs_preopen()
     test_paper_wired_1h_not_s17()
     test_gap_compare_groups_every_tf_and_gap()
     print("ALL test_s16_hhhl_wick OK")

--- a/goldpetal/test_strategy_hhhl_day.py
+++ b/goldpetal/test_strategy_hhhl_day.py
@@ -273,6 +273,52 @@ def test_sql_seed_hydrates_today_from_ticks_db() -> None:
         db.unlink()
 
 
+def test_seed_replaces_stale_prev_close() -> None:
+    import sqlite3
+
+    state = Path("/tmp/s13_test_stale_prev_close.json")
+    db = Path("/tmp/s13_test_stale_prev_close.db")
+    if db.exists():
+        db.unlink()
+    con = sqlite3.connect(str(db))
+    con.execute(
+        "CREATE TABLE ticks (id INTEGER PRIMARY KEY, received_at TEXT, ltp REAL)"
+    )
+    con.executemany(
+        "INSERT INTO ticks (received_at, ltp) VALUES (?, ?)",
+        [
+            ("2026-08-17T09:00:00+05:30", 15000.0),
+            ("2026-08-17T12:00:00+05:30", 15480.0),
+            ("2026-08-17T23:20:00+05:30", 15200.0),
+        ],
+    )
+    con.commit()
+    con.close()
+    s = _fresh(str(state))
+    s.prev_day = DayOhlc("2026-08-17", 15000.0, 15400.0, 15000.0, 15400.0)
+    s._seed_from_ticks(db, today="2026-08-18")
+    assert s.prev_day is not None
+    assert s.prev_day.date == "2026-08-17"
+    assert s.prev_day.close == 15200.0
+    assert s.prev_day.high == 15480.0
+    if state.exists():
+        state.unlink()
+    if db.exists():
+        db.unlink()
+
+
+def test_next_open_does_not_clobber_sql_prev_close() -> None:
+    s = _fresh("/tmp/s13_test_roll_keep_sql_close.json")
+    s.prev_day = DayOhlc("2026-08-17", 15000.0, 15480.0, 15000.0, 15200.0)
+    s._day = DayOhlc("2026-08-17", 15000.0, 15480.0, 15000.0, 15400.0)
+    s.on_tick(_ts("2026-08-18", "09:00"), 15300.0)
+    assert s.prev_day is not None
+    assert s.prev_day.date == "2026-08-17"
+    assert s.prev_day.close == 15200.0
+    assert s._day is not None and s._day.date == "2026-08-18"
+    Path("/tmp/s13_test_roll_keep_sql_close.json").unlink(missing_ok=True)
+
+
 def _front_contract(*, days_left: int, rolled: bool = False, symbol: str = "GOLDPETAL31AUG26FUT") -> dict:
     return {
         "symbol": symbol,
@@ -351,6 +397,10 @@ if __name__ == "__main__":
     print("ok persist")
     test_sql_seed_hydrates_today_from_ticks_db()
     print("ok sql seed")
+    test_seed_replaces_stale_prev_close()
+    print("ok stale prev close")
+    test_next_open_does_not_clobber_sql_prev_close()
+    print("ok roll keeps sql close")
     test_last_front_session_closes_and_blocks()
     print("ok last front flatten")
     test_contract_switch_closes_and_resets_book()

--- a/goldpetal/test_strategy_s16.py
+++ b/goldpetal/test_strategy_s16.py
@@ -149,6 +149,119 @@ def test_overnight_leftover_closes_at_next_open() -> None:
     assert "overnight leftover" in (close.reason or "")
 
 
+def test_yesterday_prev_does_not_fill_first_hour() -> None:
+    from backtest_hhhl_candles import Candle
+
+    s = _s16()
+    s._prev = Candle("2026-08-16 22:00:00", 90.0, 140.0, 80.0, 80.0)
+    s.on_tick(_t(9, 0), 100.0)
+    s.on_tick(_t(9, 10), 105.0)
+    s.on_tick(_t(9, 20), 99.0)
+    s.on_tick(_t(9, 59), 104.0)
+    assert s.on_tick(_t(10, 0), 100.0) is None
+    assert s.position == "flat"
+    assert s.last_skip == "need_prev_1h"
+    assert s._prev is not None
+    assert s._prev.time.startswith("2026-08-17 09:00")
+    assert s._prev.close == 104.0
+
+
+def test_preopen_prev_does_not_fill_first_hour() -> None:
+    from backtest_hhhl_candles import Candle
+
+    s = _s16()
+    s._prev = Candle("2026-08-17 08:00:00", 90.0, 140.0, 80.0, 80.0)
+    s.on_tick(_t(9, 0), 100.0)
+    s.on_tick(_t(9, 10), 105.0)
+    s.on_tick(_t(9, 20), 99.0)
+    s.on_tick(_t(9, 59), 104.0)
+    assert s.on_tick(_t(10, 0), 100.0) is None
+    assert s.position == "flat"
+    assert s.last_skip == "need_prev_1h"
+
+
+def test_second_hour_picks_side_after_stale_prev() -> None:
+    from backtest_hhhl_candles import Candle
+
+    s = _s16()
+    s._prev = Candle("2026-08-16 22:00:00", 90.0, 140.0, 80.0, 80.0)
+    s.on_tick(_t(9, 0), 100.0)
+    s.on_tick(_t(9, 10), 105.0)
+    s.on_tick(_t(9, 20), 99.0)
+    s.on_tick(_t(9, 59), 104.0)
+    assert s.on_tick(_t(10, 0), 100.0) is None
+    s.on_tick(_t(10, 10), 120.0)
+    s.on_tick(_t(10, 59), 110.0)
+    result = s.on_tick(_t(11, 0), 110.0)
+    assert result is not None
+    assert result.action == "BUY"
+    assert "C>prev → HH+green" in result.reason
+    assert s.entry_price == 110.0
+
+
+def test_seed_skips_preopen_and_yesterday() -> None:
+    import sqlite3
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as td:
+        db = Path(td) / "ticks.db"
+        con = sqlite3.connect(str(db))
+        con.execute(
+            "CREATE TABLE ticks (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "received_at TEXT NOT NULL, ltp REAL)"
+        )
+        con.executemany(
+            "INSERT INTO ticks (received_at, ltp) VALUES (?, ?)",
+            [
+                ("2026-08-16T23:00:00+05:30", 90.0),
+                ("2026-08-16T23:59:00+05:30", 80.0),
+                ("2026-08-17T08:00:00+05:30", 90.0),
+                ("2026-08-17T08:59:00+05:30", 80.0),
+                ("2026-08-17T09:00:00+05:30", 100.0),
+                ("2026-08-17T09:10:00+05:30", 101.0),
+            ],
+        )
+        con.commit()
+        con.close()
+        s = _s16()
+        s.seed_from_ticks(db, now=_t(9, 15))
+        assert s._prev is None
+        s.seed_from_ticks(db, now=datetime(2026, 8, 17, 0, 30, tzinfo=IST))
+        assert s._prev is None
+
+
+def test_seed_keeps_todays_closed_session_hour() -> None:
+    import sqlite3
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as td:
+        db = Path(td) / "ticks.db"
+        con = sqlite3.connect(str(db))
+        con.execute(
+            "CREATE TABLE ticks (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "received_at TEXT NOT NULL, ltp REAL)"
+        )
+        con.executemany(
+            "INSERT INTO ticks (received_at, ltp) VALUES (?, ?)",
+            [
+                ("2026-08-17T09:00:00+05:30", 100.0),
+                ("2026-08-17T09:10:00+05:30", 105.0),
+                ("2026-08-17T09:59:00+05:30", 104.0),
+                ("2026-08-17T10:00:00+05:30", 100.0),
+                ("2026-08-17T10:10:00+05:30", 101.0),
+            ],
+        )
+        con.commit()
+        con.close()
+        s = _s16()
+        s.seed_from_ticks(db, now=_t(10, 15))
+        assert s._prev is not None
+        assert s._prev.time.startswith("2026-08-17 09:00")
+        assert s._prev.close == 104.0
+
+
 if __name__ == "__main__":
     test_forming_hour_does_not_trade()
     test_first_closed_hour_needs_prev()
@@ -159,4 +272,9 @@ if __name__ == "__main__":
     test_on_bar_row_uses_prev()
     test_flatten_at_market_close()
     test_overnight_leftover_closes_at_next_open()
+    test_yesterday_prev_does_not_fill_first_hour()
+    test_preopen_prev_does_not_fill_first_hour()
+    test_second_hour_picks_side_after_stale_prev()
+    test_seed_skips_preopen_and_yesterday()
+    test_seed_keeps_todays_closed_session_hour()
     print("ALL test_strategy_s16 OK")

--- a/goldpetal/test_strategy_s16.py
+++ b/goldpetal/test_strategy_s16.py
@@ -260,6 +260,120 @@ def test_seed_keeps_todays_closed_session_hour() -> None:
         assert s._prev is not None
         assert s._prev.time.startswith("2026-08-17 09:00")
         assert s._prev.close == 104.0
+        assert s.on_tick(_t(10, 15), 101.0) is None
+        assert s.position == "flat"
+
+
+def _ticks_db(rows: list[tuple[str, float]]):
+    import sqlite3
+    import tempfile
+    from pathlib import Path
+
+    td = tempfile.TemporaryDirectory()
+    db = Path(td.name) / "ticks.db"
+    con = sqlite3.connect(str(db))
+    con.execute(
+        "CREATE TABLE ticks (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "received_at TEXT NOT NULL, token TEXT, ltp REAL, raw_json TEXT DEFAULT '{}')"
+    )
+    con.executemany("INSERT INTO ticks (received_at, ltp) VALUES (?, ?)", rows)
+    con.commit()
+    con.close()
+    return td, db
+
+
+def test_restart_after_4pm_catches_up_closed_hour() -> None:
+    """Restart at 16:07 must still decide 15:00 vs 14:00 (missed 16:00 tick)."""
+    td, db = _ticks_db(
+        [
+            ("2026-08-17T14:00:00+05:30", 100.0),
+            ("2026-08-17T14:10:00+05:30", 105.0),
+            ("2026-08-17T14:20:00+05:30", 99.0),
+            ("2026-08-17T14:59:00+05:30", 104.0),
+            ("2026-08-17T15:00:00+05:30", 100.0),
+            ("2026-08-17T15:10:00+05:30", 120.0),
+            ("2026-08-17T15:59:00+05:30", 110.0),
+            ("2026-08-17T16:00:00+05:30", 110.0),
+            ("2026-08-17T16:07:00+05:30", 111.0),
+        ]
+    )
+    try:
+        s = _s16()
+        s.seed_from_ticks(db, now=_t(16, 7))
+        result = s.on_tick(_t(16, 7), 111.0)
+        assert result is not None
+        assert result.action == "BUY"
+        assert "C>prev → HH+green" in result.reason
+        assert "restart catch-up" in result.reason
+        assert s.position == "long"
+        assert s.entry_price == 110.0
+        assert s.on_tick(_t(16, 20), 112.0) is None
+        assert s.position == "long"
+    finally:
+        td.cleanup()
+
+
+def test_restart_catchup_skips_when_formula_has_no_side() -> None:
+    td, db = _ticks_db(
+        [
+            ("2026-08-17T14:00:00+05:30", 100.0),
+            ("2026-08-17T14:10:00+05:30", 120.0),
+            ("2026-08-17T14:59:00+05:30", 104.0),
+            ("2026-08-17T15:00:00+05:30", 104.0),
+            ("2026-08-17T15:10:00+05:30", 104.5),
+            ("2026-08-17T15:20:00+05:30", 90.0),
+            ("2026-08-17T15:59:00+05:30", 104.2),
+            ("2026-08-17T16:07:00+05:30", 104.2),
+        ]
+    )
+    try:
+        s = _s16()
+        s.seed_from_ticks(db, now=_t(16, 7))
+        assert s.on_tick(_t(16, 7), 104.2) is None
+        assert s.position == "flat"
+        assert "no HH/LL" in str(s.last_skip)
+    finally:
+        td.cleanup()
+
+
+def test_restart_does_not_repeat_already_recorded_close() -> None:
+    from storage import init_db, save_signal
+
+    td, db = _ticks_db(
+        [
+            ("2026-08-17T14:00:00+05:30", 100.0),
+            ("2026-08-17T14:10:00+05:30", 105.0),
+            ("2026-08-17T14:59:00+05:30", 104.0),
+            ("2026-08-17T15:00:00+05:30", 100.0),
+            ("2026-08-17T15:10:00+05:30", 120.0),
+            ("2026-08-17T15:59:00+05:30", 110.0),
+            ("2026-08-17T16:07:00+05:30", 111.0),
+        ]
+    )
+    try:
+        init_db(db)
+        save_signal(
+            time_label="2026-08-17T16:00:05+05:30",
+            symbol="GOLDPETAL",
+            action="BUY",
+            position_after="long",
+            reason="live 16:00 close",
+            price_delta=None,
+            net=0.0,
+            net_delta=None,
+            dry_run=True,
+            strategy="S16_HHHL_WICK_1H",
+            cmp=110.0,
+            db_path=db,
+        )
+        s = _s16()
+        s.seed_from_ticks(db, now=_t(16, 7))
+        assert s.position == "long"
+        assert s.on_tick(_t(16, 7), 111.0) is None
+        assert s.position == "long"
+        assert s.entry_price == 110.0
+    finally:
+        td.cleanup()
 
 
 if __name__ == "__main__":
@@ -277,4 +391,7 @@ if __name__ == "__main__":
     test_second_hour_picks_side_after_stale_prev()
     test_seed_skips_preopen_and_yesterday()
     test_seed_keeps_todays_closed_session_hour()
+    test_restart_after_4pm_catches_up_closed_hour()
+    test_restart_catchup_skips_when_formula_has_no_side()
+    test_restart_does_not_repeat_already_recorded_close()
     print("ALL test_strategy_s16 OK")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Qty TBQ/TSQ is out. This branch is off `cursor/s4-off-desk-a4b2`. Do not merge https://github.com/Sampreeth1608/stockAutomation/pull/31.

S16:
- first finished session 1h stores prev, no trade
- next finished session 1h can BUY/SHORT only if close-vs-prev picks a side
- never use yesterday or preopen as prev
- restart after an hour already closed still applies that last session 1h vs the hour before it (fill at that bar’s close), unless a signal was already recorded at/after that close
- flatten at MARKET_CLOSE

S13:
- last 15m only, previous-day close is the last tick after restart

On the VM: `git pull origin cursor/s16-session-side-a4b2` then type **RESTART** on Engine before 17:00 IST so the 16:00 close can catch up. Keep `DRY_RUN=true`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e92370bb-ed6a-433d-8b83-fe612227a4b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e92370bb-ed6a-433d-8b83-fe612227a4b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

