### PR TITLE
Rank S11 after charges and only propose packs that beat paper

### DIFF
--- a/goldpetal/discover_strategies.py
+++ b/goldpetal/discover_strategies.py
@@ -6,12 +6,15 @@ Pipeline:
      (price, book L1–L5, TBQ/TSQ, OI, volume, spread/microprice)
   2) Generate strategy recipes from that behavior understanding
   3) Train logreg / RF / GB on predictive features
-  4) Fee-aware paper sim → weekend proposal (S11)
+  4) Paper sim ranked on profit after Angel charges (tax excluded) → ML proposal
 
   python3 discover_strategies.py run --db data/ticks.db
   ./weekly_discover.sh
 
-Nothing enables paper/live until you approve the proposal and set env_patch.
+First S11 pack: pending only if after-charges profit > 0 and safety_ok.
+After you Approve → paper, later weeks still train, but a pending row
+appears only when a new pack beats the loaded pack on the same test
+ticks (after charges, tax excluded). Nothing goes live from ML.
 """
 
 from __future__ import annotations
@@ -73,14 +76,15 @@ class Candidate:
     win_rate: float
     gross_pnl: float
     after_tax_pnl: float
-    safety_ok: bool
+    after_charges_pnl: float = 0.0
+    safety_ok: bool = False
     safety_reasons: list[str] = field(default_factory=list)
     pack_path: str = ""
     model_path: str = ""
     behavior_summary: str = ""
 
     def score(self) -> float:
-        return float(self.after_tax_pnl) + 0.5 * min(self.n_trades, 40)
+        return float(self.after_charges_pnl) + 0.5 * min(self.n_trades, 40)
 
 
 TEMPLATES: list[Template] = [
@@ -205,8 +209,10 @@ def paper_sim(
         trades.append(
             {
                 "gross": float(bits["gross_pnl"]),
+                "after_charges": float(bits["pnl_after_charges"]),
                 "after_tax": float(bits["pnl_after_tax"]),
-                "win": 1.0 if float(bits["gross_pnl"]) > 0 else 0.0,
+                "fees": float(bits["charges"]),
+                "win": 1.0 if float(bits["pnl_after_charges"]) > 0 else 0.0,
             }
         )
         side = 0
@@ -251,18 +257,23 @@ def paper_sim(
         _close(float(ltp[-1]))
 
     n = len(trades)
+    empty = {
+        "n_trades": 0,
+        "win_rate": 0.0,
+        "gross_pnl": 0.0,
+        "after_charges_pnl": 0.0,
+        "after_tax_pnl": 0.0,
+        "fees_inr": 0.0,
+    }
     if n == 0:
-        return {
-            "n_trades": 0,
-            "win_rate": 0.0,
-            "gross_pnl": 0.0,
-            "after_tax_pnl": 0.0,
-        }
+        return empty
     return {
         "n_trades": float(n),
         "win_rate": float(np.mean([t["win"] for t in trades])),
         "gross_pnl": float(np.sum([t["gross"] for t in trades])),
+        "after_charges_pnl": float(np.sum([t["after_charges"] for t in trades])),
         "after_tax_pnl": float(np.sum([t["after_tax"] for t in trades])),
+        "fees_inr": float(np.sum([t["fees"] for t in trades])),
     }
 
 
@@ -279,17 +290,85 @@ def _safety(auc: float, sim: dict[str, float]) -> tuple[bool, list[str]]:
         reasons.append(f"n_trades={int(sim['n_trades'])}<5")
     else:
         reasons.append(f"n_trades={int(sim['n_trades'])} ok")
-    if sim["after_tax_pnl"] <= 0:
+    after_ch = float(sim.get("after_charges_pnl") or 0)
+    if after_ch <= 0:
         ok = False
-        reasons.append(f"after_tax={sim['after_tax_pnl']:.1f}<=0")
+        reasons.append(f"after_charges={after_ch:.1f}<=0")
     else:
-        reasons.append(f"after_tax={sim['after_tax_pnl']:.1f} ok")
+        reasons.append(f"after_charges={after_ch:.1f} ok")
     if sim["win_rate"] < 0.45:
         ok = False
         reasons.append(f"win_rate={sim['win_rate']:.2f}<0.45")
     else:
         reasons.append(f"win_rate={sim['win_rate']:.2f} ok")
     return ok, reasons
+
+
+def _env_pack_path(raw: str) -> str:
+    """S11_PACK_PATH must start with data/ when applied from the ML tab."""
+    s = str(raw or "").replace("\\", "/")
+    if "data/discover/" in s:
+        return "data/discover/" + s.split("data/discover/", 1)[1]
+    return s
+
+
+def template_from_pack(pack: dict[str, Any]) -> Template:
+    return Template(
+        name=str(pack.get("id") or "loaded"),
+        buy_prob=float(pack.get("buy_prob", 0.58)),
+        short_prob=float(pack.get("short_prob", 0.42)),
+        min_hold=int(float(pack.get("min_hold_sec", 30))),
+        min_imb=float(pack.get("min_imb", 0.0)),
+        every_n=int(pack.get("every_n_ticks", 5)),
+        features=list(pack.get("features") or FEATURE_COLUMNS),
+        rationale=str(pack.get("rationale") or ""),
+        family=str(pack.get("family") or "loaded"),
+    )
+
+
+def sim_pack_on_test(pack_path: Path, test_df: pd.DataFrame) -> dict[str, Any]:
+    """Replay the loaded S11 pack on this week's test ticks. After charges, no tax."""
+    if not pack_path.is_file():
+        return {"ok": False, "error": "pack missing", "path": str(pack_path)}
+    try:
+        pack = json.loads(pack_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        return {"ok": False, "error": f"pack read failed: {exc}", "path": str(pack_path)}
+    model_path = Path(str(pack.get("model_path") or ""))
+    if not model_path.is_file():
+        return {"ok": False, "error": "model missing", "path": str(pack_path)}
+    try:
+        blob = joblib.load(model_path)
+    except Exception as exc:
+        return {"ok": False, "error": f"model load failed: {exc}", "path": str(pack_path)}
+    model = blob["model"] if isinstance(blob, dict) and "model" in blob else blob
+    feats = [c for c in (pack.get("features") or FEATURE_COLUMNS) if c in test_df.columns]
+    if len(feats) < 2:
+        return {"ok": False, "error": "pack features missing on test ticks", "path": str(pack_path)}
+    tmpl = template_from_pack(pack)
+    need = list(feats) + ["ltp"]
+    if "imb_l1" in test_df.columns:
+        need.append("imb_l1")
+    clean = test_df.dropna(subset=[c for c in need if c in test_df.columns]).copy()
+    if clean.empty:
+        return {"ok": False, "error": "empty test after dropna", "path": str(pack_path)}
+    try:
+        prob = model.predict_proba(clean[feats].astype(float))[:, 1]
+    except Exception as exc:
+        return {"ok": False, "error": f"predict failed: {exc}", "path": str(pack_path)}
+    ltp = clean["ltp"].to_numpy(dtype=float)
+    imb = (
+        clean["imb_l1"].to_numpy(dtype=float)
+        if "imb_l1" in clean.columns
+        else np.zeros(len(clean))
+    )
+    sim = paper_sim(ltp=ltp, prob=prob, imb=imb, template=tmpl)
+    return {
+        "ok": True,
+        "path": str(pack_path),
+        "pack_id": str(pack.get("id") or pack_path.stem),
+        **sim,
+    }
 
 
 def write_pack(
@@ -359,6 +438,7 @@ def run_discovery(
     threshold_bps: float = 2.0,
     train_frac: float = 0.7,
     top_k: int = 1,
+    loaded_pack_path: Path | str | None = None,
 ) -> list[Candidate]:
     raw = load_ticks_csv(csv_path)
     if len(raw) < 400:
@@ -460,6 +540,7 @@ def run_discovery(
                     win_rate=float(sim["win_rate"]),
                     gross_pnl=float(sim["gross_pnl"]),
                     after_tax_pnl=float(sim["after_tax_pnl"]),
+                    after_charges_pnl=float(sim["after_charges_pnl"]),
                     safety_ok=ok,
                     safety_reasons=reasons,
                     pack_path=str(pack_path),
@@ -469,6 +550,11 @@ def run_discovery(
             )
 
     cands.sort(key=lambda c: (c.safety_ok, c.score()), reverse=True)
+    current_pack: dict[str, Any] | None = None
+    if loaded_pack_path:
+        loaded = Path(loaded_pack_path)
+        if str(loaded):
+            current_pack = sim_pack_on_test(loaded, test_df)
     report = {
         "week_id": week,
         "csv": str(csv_path),
@@ -479,6 +565,8 @@ def run_discovery(
         "behavior_report": str(behavior_path),
         "behavior_summary": behavior.summary,
         "reasoning": behavior.reasoning,
+        "metric": "after_charges_ex_tax",
+        "current_pack": current_pack,
         "predictive_families": [asdict(f) for f in behavior.families if f.predictive],
         "recipes": [asdict(r) for r in behavior.recipes],
         "candidates": [
@@ -491,6 +579,7 @@ def run_discovery(
                 "n_trades": c.n_trades,
                 "win_rate": c.win_rate,
                 "gross_pnl": c.gross_pnl,
+                "after_charges_pnl": c.after_charges_pnl,
                 "after_tax_pnl": c.after_tax_pnl,
                 "safety_ok": c.safety_ok,
                 "safety_reasons": c.safety_reasons,
@@ -506,43 +595,68 @@ def run_discovery(
     return cands[: max(1, top_k)]
 
 
-def propose_best(cands: list[Candidate], *, note: str = "") -> StrategyProposal | None:
-    if not cands:
+def propose_best(
+    cands: list[Candidate],
+    *,
+    note: str = "",
+    current: dict[str, Any] | None = None,
+    proposals_path: Path | None = None,
+) -> StrategyProposal | None:
+    """Pending ML row only for a first pack, or a pack that beats the loaded one."""
+    eligible = [
+        c
+        for c in cands
+        if c.safety_ok and float(c.after_charges_pnl) > 0
+    ]
+    if not eligible:
         return None
-    best = cands[0]
+    best = eligible[0]
+    if current:
+        if not current.get("ok"):
+            return None
+        if not current.get("path"):
+            return None
+    current_ok = bool(current and current.get("ok") and current.get("path"))
+    win_ch = float(best.after_charges_pnl)
+    if current_ok:
+        cur_ch = float(current.get("after_charges_pnl") or 0)
+        try:
+            same = Path(best.pack_path).resolve() == Path(str(current.get("path"))).resolve()
+        except OSError:
+            same = str(best.pack_path) == str(current.get("path"))
+        if same or win_ch <= cur_ch:
+            return None
+        kind = "improved"
+        baseline = cur_ch
+        delta = round(win_ch - cur_ch, 2)
+        vs = (
+            f"beats loaded {current.get('pack_id') or 'pack'} "
+            f"after charges ₹{cur_ch:+.0f}"
+        )
+    else:
+        kind = "new"
+        baseline = 0.0
+        delta = win_ch
+        vs = "first pack (none loaded yet)"
     week = _week_id()
     title = (
-        f"S11 behavior+ML: {best.model_name}+{best.template.name} "
-        f"[{best.template.family}] (AUC {best.auc:.3f})"
+        f"S11 pack {best.model_name}+{best.template.name} "
+        f"[{best.template.family}] — week {week}"
     )
     summary = (
-        f"Analyzed all tick families (price/book/OI/volume/spread) with math+stats+reasoning; "
-        f"generated recipes; trained logreg/rf/gb. "
-        f"best={best.model_name}/{best.template.name} "
-        f"({best.template.rationale or best.template.family}). "
-        f"Paper: trades={best.n_trades} win={best.win_rate:.0%} "
-        f"gross={best.gross_pnl:.1f} after_tax={best.after_tax_pnl:.1f}. "
-        f"Behavior: {best.behavior_summary[:220]} "
-        f"Approve → S11_PACK_PATH + ENABLE_S11 (DRY_RUN). {note}"
+        f"{best.model_name}/{best.template.name} after charges ₹{win_ch:+.0f} "
+        f"vs {vs} (tax excluded), test trades={best.n_trades}, "
+        f"win={best.win_rate:.0%}, AUC={best.auc:.3f}. Paper only. {note}"
     ).strip()
     env_patch = {
         "DRY_RUN": "true",
+        "ENABLE_S11": "true",
+        "S11_PACK_PATH": _env_pack_path(best.pack_path),
     }
-    if best.safety_ok:
-        env_patch["ENABLE_S11"] = "true"
-        env_patch["S11_PACK_PATH"] = best.pack_path
-    else:
-        # Do not tempt operators to enable a failing pack
-        env_patch["ENABLE_S11"] = "false"
-        env_patch["S11_PACK_PATH"] = ""
-        summary = (
-            summary
-            + " DO NOT enable — safety_ok=False (after-tax/AUC/trades gates failed)."
-        )
     prop = StrategyProposal(
         id="",
         week_id=week,
-        kind="new",
+        kind=kind,
         strategy="S11_DISCOVERED",
         title=title,
         summary=summary,
@@ -550,21 +664,27 @@ def propose_best(cands: list[Candidate], *, note: str = "") -> StrategyProposal 
             n_trades=best.n_trades,
             win_rate=best.win_rate,
             gross_pnl_inr=best.gross_pnl,
-            after_tax_pnl_inr=best.after_tax_pnl,
-            baseline_after_tax_inr=0.0,
-            delta_vs_baseline_inr=best.after_tax_pnl,
+            after_tax_pnl_inr=win_ch,
+            baseline_after_tax_inr=baseline,
+            delta_vs_baseline_inr=delta,
             extra={
+                "metric": "after_charges_ex_tax",
+                "after_charges_inr": win_ch,
+                "after_tax_inr": float(best.after_tax_pnl),
                 "auc": best.auc,
                 "model": best.model_name,
                 "template": best.template.name,
                 "family": best.template.family,
                 "rationale": best.template.rationale,
                 "behavior_summary": best.behavior_summary,
+                "current_pack": (current or {}).get("pack_id") if current_ok else "",
+                "current_after_charges_inr": baseline if current_ok else None,
                 "runners_up": [
                     {
                         "model": c.model_name,
                         "template": c.template.name,
                         "family": c.template.family,
+                        "after_charges": c.after_charges_pnl,
                         "after_tax": c.after_tax_pnl,
                         "auc": c.auc,
                         "safety_ok": c.safety_ok,
@@ -574,11 +694,25 @@ def propose_best(cands: list[Candidate], *, note: str = "") -> StrategyProposal 
             },
         ),
         model_path=best.model_path,
-        safety_ok=best.safety_ok,
-        safety_reasons=best.safety_reasons,
+        safety_ok=True,
+        safety_reasons=list(best.safety_reasons),
         env_patch=env_patch,
     )
+    if proposals_path is not None:
+        return add_proposal(prop, path=proposals_path)
     return add_proposal(prop)
+
+
+def _loaded_pack_from_env(explicit: str = "") -> str:
+    raw = (explicit or "").strip()
+    if raw:
+        return raw
+    try:
+        from analytics.env_bridge import read_env
+
+        return str(read_env().get("S11_PACK_PATH") or "").strip()
+    except Exception:
+        return ""
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -590,6 +724,12 @@ def cmd_run(args: argparse.Namespace) -> int:
         csv_path = out_dir / "ticks_export.csv"
         n = export_full_ticks(csv_path, limit=args.limit)
         print(f"exported {n} ticks → {csv_path}")
+    loaded = _loaded_pack_from_env(getattr(args, "loaded_pack", "") or "")
+    print("S11 learner (ML proposal, after charges exclude tax, not live)")
+    if loaded:
+        print(f"loaded pack {loaded}")
+    else:
+        print("no loaded S11 pack — first profitable pack can go to ML")
     cands = run_discovery(
         csv_path=csv_path,
         out_dir=out_dir,
@@ -597,18 +737,43 @@ def cmd_run(args: argparse.Namespace) -> int:
         threshold_bps=args.threshold_bps,
         train_frac=args.train_frac,
         top_k=args.top_k,
+        loaded_pack_path=loaded or None,
     )
+    report: dict[str, Any] = {}
+    latest = out_dir / "latest_report.json"
+    if latest.is_file():
+        try:
+            raw = json.loads(latest.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                report = raw
+        except json.JSONDecodeError:
+            report = {}
+    current = report.get("current_pack") if isinstance(report.get("current_pack"), dict) else None
     for i, c in enumerate(cands):
         print(
             f"[{i}] {c.model_name}/{c.template.name} ({c.template.family}) "
             f"auc={c.auc:.3f} trades={c.n_trades} "
-            f"after_tax={c.after_tax_pnl:.1f} safety={c.safety_ok} "
+            f"after_charges₹={c.after_charges_pnl:.1f} safety={c.safety_ok} "
             f"pack={c.pack_path}"
         )
-    prop = propose_best(cands, note=args.note)
+    if current and current.get("ok"):
+        print(
+            f"current pack {current.get('pack_id')} "
+            f"after_charges₹={float(current.get('after_charges_pnl') or 0):.1f} "
+            f"on this week's test ticks"
+        )
+    elif loaded:
+        print(f"could not resim loaded pack: {(current or {}).get('error') or 'unknown'}")
+    prop = propose_best(cands, note=args.note, current=current)
     if prop:
-        print(f"proposal id={prop.id} status={prop.status} safety_ok={prop.safety_ok}")
+        print(f"proposal id={prop.id} kind={prop.kind} status={prop.status}")
         print("env_patch:", json.dumps(prop.env_patch, indent=2))
+        print("Approve → paper on the ML tab, then type RESTART. Keep DRY_RUN=true.")
+    else:
+        print(
+            "no ML proposal — kept loaded pack (or no safety-ok after-charges profit). "
+            "Models still wrote under data/discover. Approve only when a new pack beats paper."
+        )
     return 0
 
 
@@ -651,6 +816,11 @@ def main() -> None:
     run_p.add_argument("--train-frac", type=float, default=0.7)
     run_p.add_argument("--top-k", type=int, default=3)
     run_p.add_argument("--note", default="")
+    run_p.add_argument(
+        "--loaded-pack",
+        default="",
+        help="S11 pack to beat (default: S11_PACK_PATH from .env)",
+    )
     run_p.set_defaults(func=cmd_run)
 
     beh = sub.add_parser("behavior", help="Math/stats/reasoning over tick families only")

--- a/goldpetal/discover_strategies.py
+++ b/goldpetal/discover_strategies.py
@@ -458,11 +458,20 @@ def run_discovery(
         f"horizon={use_horizon} table={behavior.horizon_table}",
         flush=True,
     )
-
+    print(
+        f"building features on {len(raw)} ticks — SSH stays quiet until this finishes",
+        flush=True,
+    )
     feat = build_features(raw)
+    print(f"feature rows={len(feat)} — labeling horizon={use_horizon}", flush=True)
     labeled = add_labels(feat, horizon=use_horizon, threshold_bps=threshold_bps)
     usable = labeled.dropna(subset=FEATURE_COLUMNS + ["y_dir", "y_ret"]).copy()
     train_df, test_df = time_split(usable, train_frac=train_frac)
+    print(
+        f"train={len(train_df)} test={len(test_df)} — fitting logreg/rf/gb "
+        f"({len(templates)} recipes)",
+        flush=True,
+    )
     if train_df["y_dir"].nunique() < 2:
         raise SystemExit("train labels single-class — collect more varied ticks")
 
@@ -494,12 +503,17 @@ def run_discovery(
             aucs[feats] = {}
             probs[feats] = {"__ltp__": ltp_aligned, "__imb__": imb_aligned}
             for mname, model in _models().items():
+                print(
+                    f"fit {mname} features={len(feats)} n={len(X_train)} — wait",
+                    flush=True,
+                )
                 m = clone(model)
                 m.fit(X_train, y_train.to_numpy())
                 prob = m.predict_proba(X_test)[:, 1]
                 fitted[feats][mname] = m
                 probs[feats][mname] = prob
                 aucs[feats][mname] = _auc(y_test.to_numpy(), prob)
+                print(f"  {mname} auc={aucs[feats][mname]:.3f}", flush=True)
 
         ltp_use = probs[feats]["__ltp__"]
         imb_use = probs[feats]["__imb__"]
@@ -508,6 +522,11 @@ def run_discovery(
             auc = aucs[feats][mname]
             sim = paper_sim(ltp=ltp_use, prob=prob, imb=imb_use, template=tmpl)
             ok, reasons = _safety(auc, sim)
+            print(
+                f"sim {mname}/{tmpl.name} trades={int(sim['n_trades'])} "
+                f"after_charges₹={sim['after_charges_pnl']:.1f} safety={ok}",
+                flush=True,
+            )
             if (
                 tmpl.family != "baseline"
                 and behavior.fee_be_pts > 0

--- a/goldpetal/lite.html
+++ b/goldpetal/lite.html
@@ -93,7 +93,7 @@ label.chk { display: flex; gap: .35rem; align-items: center; color: var(--muted)
     <p class="hint" id="ml-s11-line">Loading S11 pack…</p>
     <p class="hint" id="ml-s18-line">Loading S18 pack…</p>
     <div id="ml-pending"></div>
-    <p class="hint">S18 ranks after Angel charges (tax excluded). Approve → paper, then type RESTART. Full inspector: <a href="/#ml">station ML tab</a>.</p>
+    <p class="hint">S11 and S18 rank after Angel charges (tax excluded). After the first S11 pack is approved, a new row appears only if it beats that pack. Approve → paper, then type RESTART. Full inspector: <a href="/#ml">station ML tab</a>.</p>
     <p class="flash" id="flash-ml"></p>
   </section>
 
@@ -191,8 +191,9 @@ function renderMl(d) {
     const paper = p.paper || {};
     const extra = p.extra || (paper.extra || {});
     const isS18 = p.strategy === "S18_OHLC_VOL_HTF";
-    const pnl = p.pnl_value != null ? p.pnl_value : (isS18 ? (extra.after_charges_inr ?? paper.after_tax_pnl_inr) : paper.after_tax_pnl_inr);
-    const pnlLabel = p.pnl_label || (isS18 ? "after charges ₹" : "after-tax ₹");
+    const isS11 = p.strategy === "S11_DISCOVERED";
+    const pnl = p.pnl_value != null ? p.pnl_value : ((isS18 || isS11) ? (extra.after_charges_inr ?? paper.after_tax_pnl_inr) : paper.after_tax_pnl_inr);
+    const pnlLabel = p.pnl_label || ((isS18 || isS11) ? "after charges ₹" : "after-tax ₹");
     return `<div style="border-top:1px solid var(--line);padding:.55rem 0">
       <div><b>${esc(p.title || p.strategy)}</b></div>
       <div class="hint">${esc(p.id)} · ${esc(p.strategy)} · safety ${p.safety_ok ? "ok" : "fail"} · trades ${esc(paper.n_trades ?? "—")} · ${esc(pnlLabel)} ${esc(pnl ?? "—")}</div>

--- a/goldpetal/s11_desk.py
+++ b/goldpetal/s11_desk.py
@@ -259,6 +259,7 @@ def pack_summary(raw: str | Path | None, *, root: Path = ROOT) -> dict[str, Any]
             "n_trades": paper.get("n_trades"),
             "win_rate": paper.get("win_rate"),
             "gross_pnl": paper.get("gross_pnl"),
+            "after_charges_pnl": paper.get("after_charges_pnl"),
             "after_tax_pnl": paper.get("after_tax_pnl"),
         },
         "behavior_summary": str(data.get("behavior_summary") or "")[:400],
@@ -332,6 +333,8 @@ def discover_status(*, root: Path = ROOT) -> dict[str, Any]:
     candidates: list[dict[str, Any]] = []
     summary = ""
     week_id = ""
+    current_pack: dict[str, Any] | None = None
+    metric = ""
     if report_path.is_file():
         raw_obj, err = _read_json_object(report_path)
         raw = raw_obj or {}
@@ -340,6 +343,10 @@ def discover_status(*, root: Path = ROOT) -> dict[str, Any]:
         if isinstance(raw, dict):
             summary = str(raw.get("behavior_summary") or raw.get("summary") or "")[:500]
             week_id = str(raw.get("week_id") or "")
+            metric = str(raw.get("metric") or "")
+            cur = raw.get("current_pack")
+            if isinstance(cur, dict):
+                current_pack = cur
             rows = raw.get("candidates") or []
             if isinstance(rows, list):
                 for row in rows[:8]:
@@ -354,6 +361,7 @@ def discover_status(*, root: Path = ROOT) -> dict[str, Any]:
                         "n_trades": row.get("n_trades"),
                         "win_rate": row.get("win_rate"),
                         "gross_pnl": row.get("gross_pnl"),
+                        "after_charges_pnl": row.get("after_charges_pnl"),
                         "after_tax_pnl": row.get("after_tax_pnl"),
                         "safety_ok": row.get("safety_ok"),
                         "pack_path": pack_path,
@@ -366,6 +374,8 @@ def discover_status(*, root: Path = ROOT) -> dict[str, Any]:
         "report_mtime_ist": _mtime_ist(report_path),
         "week_id": week_id,
         "behavior_summary": summary,
+        "metric": metric,
+        "current_pack": current_pack,
         "candidates": candidates,
         "cron_tail": _tail_file(cron_path, 10),
         "packs_dir": "data/discover/packs",
@@ -417,6 +427,16 @@ def _annotate_proposal(
         "n",
     }
     out["extra"] = extra
+    if str(out.get("strategy") or "") == "S11_DISCOVERED":
+        after_ch = extra.get("after_charges_inr")
+        if after_ch is None:
+            paper_pack = proposed.get("paper") if isinstance(proposed.get("paper"), dict) else {}
+            after_ch = paper_pack.get("after_charges_pnl")
+        if after_ch is None:
+            after_ch = paper.get("after_tax_pnl_inr")
+        out["pnl_label"] = "After charges ₹"
+        out["pnl_value"] = after_ch
+        return out
     out["pnl_label"] = "After-tax ₹"
     out["pnl_value"] = paper.get("after_tax_pnl_inr")
     return out
@@ -502,8 +522,10 @@ def ml_desk_payload(
         "live_blocked_reason": LIVE_BLOCKED_REASON,
         "note": (
             "Approve → paper writes S11_PACK_PATH / ENABLE_S11, or S18 active.json "
-            "+ ENABLE_S18, and keeps DRY_RUN=true. S18 ranks after charges (tax excluded). "
-            "Type RESTART on Engine to load RAM. This tab never arms Angel."
+            "+ ENABLE_S18, and keeps DRY_RUN=true. S11 and S18 rank after charges "
+            "(tax excluded). After the first S11 pack is approved, a new row appears "
+            "only when it beats that pack. Type RESTART on Engine to load RAM. "
+            "This tab never arms Angel."
         ),
     }
 

--- a/goldpetal/station.html
+++ b/goldpetal/station.html
@@ -228,7 +228,7 @@ label.chk { display: flex; gap: .35rem; align-items: center; color: var(--muted)
       </div>
       <div class="scroll" id="ml-panel" hidden>
         <h2>ML approvals — S11 + S18</h2>
-        <p class="hint">S11 weekend discovery and S18 weekly pack scores write proposals. Approve → paper keeps <span class="mono">DRY_RUN=true</span>. S18 shows profit after Angel charges (tax excluded). Type RESTART on Engine to load RAM. This tab never arms Angel.</p>
+        <p class="hint">S11 and S18 write a pending row only when a pack should be approved. Both show profit after Angel charges (tax excluded). After the first S11 pack is in paper, a new S11 row appears only if it beats that pack. Approve → paper keeps <span class="mono">DRY_RUN=true</span>. Type RESTART on Engine. This tab never arms Angel.</p>
         <div class="ml-banner" id="ml-restart" hidden>Type RESTART on Engine to load the pack into RAM. Desk restart is not enough.</div>
         <p class="flash" id="flash-ml"></p>
         <div class="row" style="margin-top:.45rem">
@@ -559,13 +559,14 @@ function renderMl() {
       ${mlStat("In .env", s11.enable_s11 ? "ENABLE_S11" : "off", s11.enable_s11 ? "ok" : "warn")}
       ${mlStat("DRY_RUN", s11.dry_run === false ? "false" : "true", s11.dry_run === false ? "bad" : "ok")}
       ${mlStat("Tape WR%", sc.win_rate != null ? pct(sc.win_rate) : "—")}
-      ${mlStat("Tape ₹", sc.pnl_after_tax != null ? money(sc.pnl_after_tax) : "—", pnlClass(sc.pnl_after_tax))}
+      ${mlStat("Tape after charges ₹", afterChargesInr(sc) != null ? money(afterChargesInr(sc)) : "—", pnlClass(afterChargesInr(sc)))}
       ${mlStat("Closed", sc.closed != null ? fmt(sc.closed, 0) : "—")}
     </div>
     <p class="mono">${esc(s11.pack_path || "(S11_PACK_PATH empty)")}</p>
     <p class="ml-meta">${packLine(pack)} · buy≥${esc(pack.buy_prob ?? "—")} short≤${esc(pack.short_prob ?? "—")} hold ${esc(pack.min_hold_sec ?? "—")}s every ${esc(pack.every_n_ticks ?? "—")}</p>
     ${pack.rationale ? `<p class="hint">${esc(pack.rationale)}</p>` : ""}
     ${pack.behavior_summary ? `<p class="hint">${esc(pack.behavior_summary)}</p>` : ""}
+    <p class="hint">S11 ranks after charges (tax excluded). After the first pack is approved, a new row appears only if it beats that pack. Type RESTART after Approve → paper.</p>
   </div>
   <div class="ml-card">
     <h3>Loaded S18 pack</h3>
@@ -586,9 +587,10 @@ function renderMl() {
     const loaded = s11.pack || {};
     const extra = p.extra || (paper.extra || {});
     const isS18 = p.strategy === "S18_OHLC_VOL_HTF";
+    const isS11 = p.strategy === "S11_DISCOVERED";
     const delta = paper.delta_vs_baseline_inr;
-    const pnlLabel = p.pnl_label || (isS18 ? "After charges ₹" : "After-tax ₹");
-    const pnlVal = p.pnl_value != null ? p.pnl_value : (isS18 ? (extra.after_charges_inr ?? paper.after_tax_pnl_inr) : paper.after_tax_pnl_inr);
+    const pnlLabel = p.pnl_label || ((isS18 || isS11) ? "After charges ₹" : "After-tax ₹");
+    const pnlVal = p.pnl_value != null ? p.pnl_value : ((isS18 || isS11) ? (extra.after_charges_inr ?? paper.after_tax_pnl_inr) : paper.after_tax_pnl_inr);
     const safety = p.safety_ok ? pill("safety ok", "ok") : pill("safety fail", "bad");
     const kind = pill(p.kind || "new", p.kind === "new" ? "ok" : "warn");
     const same = p.same_as_loaded ? pill("same as loaded", "ok") : "";
@@ -622,13 +624,13 @@ function renderMl() {
     </div>`;
   }).join("") || `<p class="hint">${pendingAll.length ? "No pending rows for this filter." : "No pending proposals. Run weekly_discover.sh (S11) or ./weekly_s18.sh (S18) on the VM."}</p>`;
   $("ml-packs").innerHTML = packs.length ? `<table>
-    <thead><tr><th>Pack</th><th>Model</th><th class="num">AUC</th><th>Safety</th><th class="num">Paper ₹</th><th></th></tr></thead>
+    <thead><tr><th>Pack</th><th>Model</th><th class="num">AUC</th><th>Safety</th><th class="num">After charges ₹</th><th></th></tr></thead>
     <tbody>${packs.map((row) => `<tr>
       <td>${row.is_loaded ? pill("loaded", "ok") + " " : ""}<span class="mono">${esc((row.path || "").replace("data/discover/packs/", ""))}</span></td>
       <td>${esc(row.model_name || "—")} ${esc(row.family || "")}</td>
       <td class="num">${aucStr(row.auc)}</td>
       <td>${row.safety_ok ? pill("ok", "ok") : pill("fail", "bad")}</td>
-      <td class="num ${pnlClass((row.paper || {}).after_tax_pnl)}">${money((row.paper || {}).after_tax_pnl)}</td>
+      <td class="num ${pnlClass((row.paper || {}).after_charges_pnl != null ? (row.paper || {}).after_charges_pnl : (row.paper || {}).after_tax_pnl)}">${money((row.paper || {}).after_charges_pnl != null ? (row.paper || {}).after_charges_pnl : (row.paper || {}).after_tax_pnl)}</td>
       <td><button class="btn ok" type="button" data-ml="load" data-path="${esc(row.path)}" data-safe="${row.safety_ok ? "1" : "0"}">${row.is_loaded ? "Reload" : "Load"}</button></td>
     </tr>`).join("")}</tbody>
   </table>` : `<p class="hint">No packs yet under data/discover/packs.</p>`;
@@ -636,13 +638,14 @@ function renderMl() {
   $("ml-discover").innerHTML = `<div class="ml-card">
     <p class="ml-meta">${esc(disc.report_path || "no latest_report.json")} ${disc.report_mtime_ist ? "· " + esc(disc.report_mtime_ist) : ""}</p>
     ${disc.behavior_summary ? `<p>${esc(disc.behavior_summary)}</p>` : `<p class="hint">No discovery report yet. Cron: Sunday 19:00 IST weekly_discover.sh</p>`}
-    ${cands.length ? `<table style="margin-top:.45rem"><thead><tr><th>Model</th><th>Template</th><th class="num">AUC</th><th class="num">Trades</th><th class="num">After-tax</th><th>Safety</th><th></th></tr></thead><tbody>
+    ${disc.current_pack && disc.current_pack.ok ? `<p class="hint">Loaded pack this week after charges ₹${esc(disc.current_pack.after_charges_pnl)} (tax excluded). A pending row appears only if a candidate beats that.</p>` : ""}
+    ${cands.length ? `<table style="margin-top:.45rem"><thead><tr><th>Model</th><th>Template</th><th class="num">AUC</th><th class="num">Trades</th><th class="num">After charges</th><th>Safety</th><th></th></tr></thead><tbody>
       ${cands.map((c) => `<tr>
         <td>${esc(c.model || "")}</td>
         <td>${esc(c.template || "")} ${esc(c.family || "")}</td>
         <td class="num">${aucStr(c.auc)}</td>
         <td class="num">${fmt(c.n_trades, 0)}</td>
-        <td class="num ${pnlClass(c.after_tax_pnl)}">${money(c.after_tax_pnl)}</td>
+        <td class="num ${pnlClass(c.after_charges_pnl != null ? c.after_charges_pnl : c.after_tax_pnl)}">${money(c.after_charges_pnl != null ? c.after_charges_pnl : c.after_tax_pnl)}</td>
         <td>${c.safety_ok ? pill("ok", "ok") : pill("fail", "bad")}</td>
         <td>${c.pack_path ? `<button class="btn ok" type="button" data-ml="load" data-path="${esc(c.pack_path)}" data-safe="${c.safety_ok ? "1" : "0"}">Load</button>` : ""}</td>
       </tr>`).join("")}

--- a/goldpetal/test_discover_strategies.py
+++ b/goldpetal/test_discover_strategies.py
@@ -8,7 +8,13 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from discover_strategies import TEMPLATES, paper_sim, run_discovery
+from discover_strategies import (
+    TEMPLATES,
+    Candidate,
+    paper_sim,
+    propose_best,
+    run_discovery,
+)
 from strategy_discovered import DiscoveredStrategy
 
 
@@ -72,6 +78,83 @@ def test_paper_sim_runs() -> None:
     sim = paper_sim(ltp=ltp, prob=prob, imb=imb, template=TEMPLATES[1])
     assert "n_trades" in sim
     assert sim["n_trades"] >= 0
+    assert "after_charges_pnl" in sim
+    assert "after_tax_pnl" in sim
+    if sim["n_trades"]:
+        assert sim["after_charges_pnl"] >= sim["after_tax_pnl"]
+
+
+def _cand(path: str, after_charges: float, *, safety_ok: bool = True) -> Candidate:
+    return Candidate(
+        model_name="logreg",
+        template=TEMPLATES[1],
+        auc=0.62,
+        n_trades=12,
+        win_rate=0.55,
+        gross_pnl=after_charges + 80,
+        after_tax_pnl=after_charges * 0.7,
+        after_charges_pnl=after_charges,
+        safety_ok=safety_ok,
+        pack_path=path,
+        model_path=path.replace(".json", ".joblib"),
+    )
+
+
+def test_propose_first_pack_then_only_if_beats(tmp_path: Path) -> None:
+    props = tmp_path / "proposals.json"
+    first = propose_best(
+        [_cand(str(tmp_path / "data/discover/packs/a.json"), 400.0)],
+        current=None,
+        proposals_path=props,
+    )
+    assert first is not None
+    assert first.kind == "new"
+    assert first.paper.extra["metric"] == "after_charges_ex_tax"
+    assert first.paper.extra["after_charges_inr"] == 400.0
+    assert first.paper.after_tax_pnl_inr == 400.0
+    assert first.env_patch["DRY_RUN"] == "true"
+    assert first.env_patch["ENABLE_S11"] == "true"
+
+    worse = propose_best(
+        [_cand(str(tmp_path / "data/discover/packs/b.json"), 300.0)],
+        current={
+            "ok": True,
+            "path": str(tmp_path / "data/discover/packs/a.json"),
+            "pack_id": "a",
+            "after_charges_pnl": 400.0,
+        },
+        proposals_path=props,
+    )
+    assert worse is None
+
+    better = propose_best(
+        [_cand(str(tmp_path / "data/discover/packs/c.json"), 520.0)],
+        current={
+            "ok": True,
+            "path": str(tmp_path / "data/discover/packs/a.json"),
+            "pack_id": "a",
+            "after_charges_pnl": 400.0,
+        },
+        proposals_path=props,
+    )
+    assert better is not None
+    assert better.kind == "improved"
+    assert better.paper.delta_vs_baseline_inr == 120.0
+    assert "tax excluded" in better.summary
+
+    blocked = propose_best(
+        [_cand(str(tmp_path / "data/discover/packs/d.json"), 900.0)],
+        current={"ok": False, "path": str(tmp_path / "data/discover/packs/a.json"), "error": "model missing"},
+        proposals_path=props,
+    )
+    assert blocked is None
+
+    unsafe = propose_best(
+        [_cand(str(tmp_path / "data/discover/packs/e.json"), 900.0, safety_ok=False)],
+        current=None,
+        proposals_path=props,
+    )
+    assert unsafe is None
 
 
 def test_discovery_writes_pack_and_proposal(tmp_path: Path) -> None:
@@ -83,6 +166,20 @@ def test_discovery_writes_pack_and_proposal(tmp_path: Path) -> None:
     pack = json.loads(Path(cands[0].pack_path).read_text(encoding="utf-8"))
     assert pack["strategy"] == "S11_DISCOVERED"
     assert "buy_prob" in pack
+    assert "after_charges_pnl" in (pack.get("paper") or {})
+    report = json.loads((out / "latest_report.json").read_text(encoding="utf-8"))
+    assert report["metric"] == "after_charges_ex_tax"
+    assert "after_charges_pnl" in report["candidates"][0]
+    round2 = tmp_path / "discover2"
+    run_discovery(
+        csv_path=csv_path,
+        out_dir=round2,
+        top_k=1,
+        loaded_pack_path=cands[0].pack_path,
+    )
+    report2 = json.loads((round2 / "latest_report.json").read_text(encoding="utf-8"))
+    assert report2["current_pack"]["ok"] is True
+    assert "after_charges_pnl" in report2["current_pack"]
     assert (out / "behavior_report.json").exists()
     behavior = json.loads((out / "behavior_report.json").read_text(encoding="utf-8"))
     assert behavior.get("families")
@@ -106,6 +203,8 @@ if __name__ == "__main__":
     t = P("/tmp/discover_test")
     test_paper_sim_runs()
     print("ok paper_sim")
+    test_propose_first_pack_then_only_if_beats(t)
+    print("ok propose_best")
     test_discovery_writes_pack_and_proposal(t)
     print("ok discovery")
     print("ALL test_discover_strategies OK")

--- a/goldpetal/test_s11_desk.py
+++ b/goldpetal/test_s11_desk.py
@@ -330,6 +330,44 @@ def test_joblib_model_path_does_not_crash_ml_tab(tmp_path: Path) -> None:
     assert pending[0]["proposed_pack"].get("error") == "empty"
 
 
+def test_s11_pending_uses_after_charges_label(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("DRY_RUN=true\nENABLE_S11=true\nS11_PACK_PATH=\n", encoding="utf-8")
+    props = tmp_path / "control" / "proposals.json"
+    add_proposal(
+        StrategyProposal(
+            id="s11ch",
+            week_id="2026-W34",
+            kind="new",
+            strategy="S11_DISCOVERED",
+            title="S11 after charges",
+            summary="first pack",
+            paper=PaperResult(
+                n_trades=8,
+                win_rate=0.5,
+                gross_pnl_inr=500.0,
+                after_tax_pnl_inr=410.0,
+                extra={
+                    "metric": "after_charges_ex_tax",
+                    "after_charges_inr": 410.0,
+                    "after_tax_inr": 300.0,
+                },
+            ),
+            safety_ok=True,
+            env_patch={
+                "ENABLE_S11": "true",
+                "S11_PACK_PATH": "data/discover/packs/week.json",
+                "DRY_RUN": "true",
+            },
+        ),
+        path=props,
+    )
+    payload = ml_desk_payload(root=tmp_path, env_path=env, proposals_path=props)
+    row = payload["proposals"]["pending"][0]
+    assert row["pnl_label"] == "After charges ₹"
+    assert row["pnl_value"] == 410.0
+
+
 if __name__ == "__main__":
     import tempfile
 
@@ -351,4 +389,6 @@ if __name__ == "__main__":
         test_reject_does_not_write_env(Path(td))
     with tempfile.TemporaryDirectory() as td:
         test_joblib_model_path_does_not_crash_ml_tab(Path(td))
+    with tempfile.TemporaryDirectory() as td:
+        test_s11_pending_uses_after_charges_label(Path(td))
     print("all s11 desk tests passed")

--- a/goldpetal/weekly_discover.sh
+++ b/goldpetal/weekly_discover.sh
@@ -10,7 +10,8 @@ if [[ -x ./venv/bin/python ]]; then
   PY=./venv/bin/python
 fi
 NOTE="week-$(date +%V)"
-exec "$PY" discover_strategies.py run \
+export PYTHONUNBUFFERED=1
+exec "$PY" -u discover_strategies.py run \
   --out-dir data/discover \
   --top-k 3 \
   --horizon 0 \

--- a/goldpetal/weekly_discover.sh
+++ b/goldpetal/weekly_discover.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Weekly multi-model strategy discovery from ticks → weekend proposal.
-# Cron (Sunday 19:00 IST):  0 19 * * 0 cd ~/goldpetal && ./weekly_discover.sh >> data/discover/cron.log 2>&1
+# Weekly S11 discovery from ticks. Trains always. ML proposal only if
+# after-charges profit (tax excluded) beats the loaded pack, or if none loaded yet.
+# Approve → paper on the station, then type RESTART. Not live.
 set -euo pipefail
 cd "$(dirname "$0")"
 mkdir -p data/discover data/discover/models data/discover/packs data/control


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
S11 now uses the same ML bar as S18.

Weekly `./weekly_discover.sh` still trains models every run. Profit is **after Angel charges, tax excluded**.

- No S11 pack in `.env` yet: a pending ML row appears only if the best pack is profitable after charges and passes safety.
- After you **Approve → paper** the first pack: later weeks still learn, but a pending row appears only if a new pack **beats the loaded pack** on the same test ticks (after charges). Ties and worse packs stay off ML. You only Approve or Reject.
- If the loaded pack cannot be replayed (missing model), no proposal is written so a broken compare cannot replace paper.

The job prints feature/fit/sim lines so SSH is not silent on a large tick export. Leave a running job alone; this logging applies to the next run.

Approve → paper keeps `DRY_RUN=true`. Type **RESTART** on Engine. This tab never arms Angel. S18 is unchanged.

On the VM, after this branch is on top of the S18 ML branch:

```bash
cd ~/goldpetal-repo
git fetch origin
git checkout cursor/s11-after-charges-beat-a4b2
git pull origin cursor/s11-after-charges-beat-a4b2
cd goldpetal
./weekly_discover.sh
./scripts/run_desk_vm.sh --restart
```

Mac Chrome: http://127.0.0.1:8501/ then Cmd+Shift+R → ML tab.

Keep `DRY_RUN=true`. Paper 100 lots ≠ live. Paper books: S5, S8, S11, S13, S16, S18. CR_* stay off. Do not paper S17.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e92370bb-ed6a-433d-8b83-fe612227a4b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e92370bb-ed6a-433d-8b83-fe612227a4b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

