### PR TITLE
OHLCV strategy lab — test each volume idea one by one; leave off desk

### DIFF
--- a/goldpetal/backtest_ohlcv_lab.py
+++ b/goldpetal/backtest_ohlcv_lab.py
@@ -6,7 +6,8 @@ after Angel charges (tax excluded) by expectancy / profit factor /
 drawdown / walk-forward. Win rate is printed last on purpose.
 
   ./venv/bin/python backtest_ohlcv_lab.py --csv /tmp/goldpetal_1h_upstox.csv \\
-      --csv-30m /tmp/goldpetal_30m_upstox.csv --lots 100 --fees
+      --csv-30m /tmp/goldpetal_30m_upstox.csv --lots 100 --fees --one-by-one
+  ./venv/bin/python backtest_ohlcv_lab.py --csv hours.csv --strategy breakout --one-by-one --lots 100 --fees
   ./venv/bin/python backtest_ohlcv_lab.py --db data/ticks.db --lots 100 --session --fees
   ./venv/bin/python backtest_ohlcv_lab.py --from-angel --from 2026-08-02 --lots 100 --fees
 """
@@ -34,6 +35,7 @@ from ohlcv_lab import (
     LabMetrics,
     after_charges_inr,
     run_lab_book,
+    selected_strategies,
     session_bars,
     trade_after_charges,
 )
@@ -261,6 +263,95 @@ def _fill_trade_stats(m: LabMetrics) -> LabMetrics:
     )
 
 
+def _print_trades(result: Any, *, title: str) -> None:
+    print()
+    print(title)
+    trades = list(getattr(result, "trades", []) or [])
+    if not trades:
+        print("  (no trades)")
+        return
+    print("  n  signal  entry_time            entry      exit_time             exit        AC₹")
+    for i, t in enumerate(trades, 1):
+        sig = "BUY  " if t.side == "LONG" else "SHORT"
+        print(
+            f"  {i:2d}  {sig}  {t.entry_time}  {t.entry_px:8.1f}  "
+            f"{t.exit_time}  {t.exit_px:8.1f}  {trade_after_charges(t):10.1f}"
+        )
+
+
+def _book_verdict(m: LabMetrics, s16: LabMetrics, s18: LabMetrics | None) -> str:
+    bits: list[str] = []
+    if m.n_trades < MIN_TRADES:
+        bits.append(f"thin sample ({m.n_trades} < {MIN_TRADES} trades)")
+    if m.after_charges <= 0:
+        bits.append("after charges ≤ 0")
+    if m.after_charges > s16.after_charges:
+        bits.append(f"beats S16 (AC₹={s16.after_charges:.1f})")
+    else:
+        bits.append(f"loses to S16 (AC₹={s16.after_charges:.1f})")
+    if s18 is not None:
+        if m.after_charges > s18.after_charges:
+            bits.append(f"beats S18 (AC₹={s18.after_charges:.1f})")
+        else:
+            bits.append(f"loses to S18 (AC₹={s18.after_charges:.1f})")
+    enough = (
+        m.n_trades >= MIN_TRADES
+        and m.after_charges > 0
+        and m.after_charges > s16.after_charges
+        and (s18 is None or m.after_charges > s18.after_charges)
+    )
+    if enough:
+        bits.append("still research — do not ENABLE unless asked to paper")
+    else:
+        bits.append("do not paper, do not ENABLE")
+    return "; ".join(bits)
+
+
+def _print_one(
+    *,
+    index: int,
+    name: str,
+    family: str,
+    idea: str,
+    rows_1h: list[LabMetrics],
+    rows_30: list[LabMetrics],
+    s16: LabMetrics,
+    s18: LabMetrics | None,
+) -> None:
+    print()
+    print("=" * 88)
+    print(f"{index}. {name}  [{family}]  {idea}")
+    print("=" * 88)
+    flip = next((m for m in rows_1h if m.name == name and m.exit_mode == EXIT_FLIP), None)
+    atr = next((m for m in rows_1h if m.name == name and m.exit_mode == EXIT_ATR), None)
+    if flip is not None:
+        print("1h flip+EOD (same hold style as S16/S18):")
+        print(" ", _fmt(flip))
+        if flip.wf_rows:
+            for i, fold in enumerate(flip.wf_rows, 1):
+                print(
+                    f"    walk-forward fold {i}: n={fold.n_trades} "
+                    f"AC₹={fold.after_charges:.1f} exp₹={fold.expectancy:.1f} "
+                    f"PF={fold.profit_factor:.2f} wr%={100.0 * fold.win_rate:.1f}"
+                )
+        print(" ", _book_verdict(flip, s16, s18))
+        if flip.result is not None:
+            _print_trades(
+                flip.result,
+                title=f"1h {name} flip+EOD BUY/SHORT (after charges, tax excluded)",
+            )
+    if atr is not None:
+        print()
+        print("1h 2ATR target / 1.5ATR trail:")
+        print(" ", _fmt(atr))
+        print(" ", _book_verdict(atr, s16, s18))
+    m30_flip = next((m for m in rows_30 if m.name == name and m.exit_mode == EXIT_FLIP), None)
+    if m30_flip is not None:
+        print()
+        print("30m flip+EOD (research baseline, not the paper 1h books):")
+        print(" ", _fmt(m30_flip))
+
+
 def _run_tf(
     bars: list[VolBar],
     *,
@@ -268,10 +359,12 @@ def _run_tf(
     lots: float,
     fees: bool,
     n_folds: int,
+    strategies: tuple[tuple[str, str, str], ...] | None = None,
 ) -> list[LabMetrics]:
     rows: list[LabMetrics] = []
     kw = dict(lots=lots, fees=fees, flatten_eod=True)
-    for name, family, _idea in STRATEGIES:
+    use = strategies or STRATEGIES
+    for name, family, _idea in use:
         for exit_mode in (EXIT_FLIP, EXIT_ATR):
             m = run_lab_book(
                 bars,
@@ -332,6 +425,17 @@ def main() -> None:
     ap.add_argument("--session", action="store_true", default=True)
     ap.add_argument("--no-session", action="store_true")
     ap.add_argument("--folds", type=int, default=3)
+    ap.add_argument(
+        "--strategy",
+        action="append",
+        default=None,
+        help="test only these lab names (repeat or comma: breakout,climax,pullback,consol,vwap,rvol_mom,three)",
+    )
+    ap.add_argument(
+        "--one-by-one",
+        action="store_true",
+        help="print each strategy separately with BUY/SHORT trades (1h flip+EOD)",
+    )
     ap.add_argument("--out-dir", default="data/backtests/ohlcv_lab")
     args = ap.parse_args()
     fees = bool(args.fees) and not bool(args.no_fees)
@@ -364,18 +468,29 @@ def main() -> None:
     if len(hours) < 25:
         raise SystemExit(f"need ≥25 1h bars, got {len(hours)} from {source}")
 
+    try:
+        picked = selected_strategies(args.strategy)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
     print(LAB_NAME, "(research — not a paper book, not live)")
     print(FORMULA)
-    for name, family, idea in STRATEGIES:
+    for name, family, idea in picked:
         print(f"  {name:10} [{family}] {idea}")
     print(
         f"lots={args.lots:g} fees={fees} session={session_filter} "
         f"hours={len(hours)} {hours[0].time}→{hours[-1].time} "
-        f"30m={len(m30)} days={len(days)} folds={args.folds} source={source}",
+        f"30m={len(m30)} days={len(days)} folds={args.folds} "
+        f"one_by_one={bool(args.one_by_one)} source={source}",
         flush=True,
     )
 
-    kw_base = dict(lots=float(args.lots), fees=fees, n_folds=int(args.folds))
+    kw_base = dict(
+        lots=float(args.lots),
+        fees=fees,
+        n_folds=int(args.folds),
+        strategies=picked,
+    )
     lab_1h = _run_tf(hours, tf="1h", **kw_base)
     s16_1h = _fill_trade_stats(
         _baseline_s16(hours, tf="1h:S16", lots=float(args.lots), fees=fees)
@@ -410,12 +525,7 @@ def main() -> None:
             )
         )
 
-    _print_table(
-        "1h OHLCV lab vs S16/S18  (after charges, tax excluded)",
-        lab_1h + [s16_1h] + ([s18_1h] if s18_1h is not None else []),
-    )
-    print(_verdict(lab_1h, s16_1h, s18_1h))
-
+    lab_30: list[LabMetrics] = []
     all_rows = list(lab_1h) + [s16_1h]
     if s18_1h is not None:
         all_rows.append(s18_1h)
@@ -425,33 +535,68 @@ def main() -> None:
         s16_30 = _fill_trade_stats(
             _baseline_s16(m30, tf="30m:S16", lots=float(args.lots), fees=fees)
         )
-        _print_table(
-            "30m OHLCV lab vs S16  (after charges, tax excluded)",
-            lab_30 + [s16_30],
-        )
-        print(_verdict(lab_30, s16_30, None))
-        print(
-            "30m S16 is a research baseline on 30m bars, not the paper 1h S16 book. "
-            "Paper rank is the 1h table vs S16 and S18."
-        )
         all_rows.extend(lab_30)
         all_rows.append(s16_30)
 
-    best = max(lab_1h, key=lambda m: m.after_charges)
-    if best.result is not None and best.result.trades:
+    if args.one_by_one:
         print()
         print(
-            f"Trade-by-trade for best 1h lab row {best.name}/{best.exit_mode} "
-            f"(BUY=LONG, SHORT=SHORT). Full CSVs under {args.out_dir}."
+            "Testing one strategy at a time on 1h (flip+EOD trades). "
+            "Rank after charges, tax excluded. S16 AC₹="
+            f"{s16_1h.after_charges:.1f}"
+            + (
+                f"  S18 AC₹={s18_1h.after_charges:.1f}"
+                if s18_1h is not None
+                else ""
+            )
+            + "."
         )
-        print_by_day([best.result])
-        # print each BUY/SHORT line for the best book
-        print("entry_time            signal  entry      exit_time            exit       AC₹")
-        for t in best.result.trades:
-            sig = "BUY  " if t.side == "LONG" else "SHORT"
+        for i, (name, family, idea) in enumerate(picked, 1):
+            _print_one(
+                index=i,
+                name=name,
+                family=family,
+                idea=idea,
+                rows_1h=lab_1h,
+                rows_30=lab_30,
+                s16=s16_1h,
+                s18=s18_1h,
+            )
+        print()
+        print("Recap vs S16/S18 (1h, after charges):")
+        _print_table(
+            "1h OHLCV lab vs S16/S18  (after charges, tax excluded)",
+            lab_1h + [s16_1h] + ([s18_1h] if s18_1h is not None else []),
+        )
+        print(_verdict(lab_1h, s16_1h, s18_1h))
+    else:
+        _print_table(
+            "1h OHLCV lab vs S16/S18  (after charges, tax excluded)",
+            lab_1h + [s16_1h] + ([s18_1h] if s18_1h is not None else []),
+        )
+        print(_verdict(lab_1h, s16_1h, s18_1h))
+        if lab_30:
+            s16_30_row = next(m for m in all_rows if m.name == "S16" and m.result and m.result.tf.startswith("30m"))
+            _print_table(
+                "30m OHLCV lab vs S16  (after charges, tax excluded)",
+                lab_30 + [s16_30_row],
+            )
+            print(_verdict(lab_30, s16_30_row, None))
             print(
-                f"{t.entry_time}  {sig}  {t.entry_px:8.1f}  "
-                f"{t.exit_time}  {t.exit_px:8.1f}  {trade_after_charges(t):10.1f}"
+                "30m S16 is a research baseline on 30m bars, not the paper 1h S16 book. "
+                "Paper rank is the 1h table vs S16 and S18."
+            )
+        best = max(lab_1h, key=lambda m: m.after_charges)
+        if best.result is not None and best.result.trades:
+            print()
+            print(
+                f"Trade-by-trade for best 1h lab row {best.name}/{best.exit_mode} "
+                f"(BUY=LONG, SHORT=SHORT). Full CSVs under {args.out_dir}."
+            )
+            print_by_day([best.result])
+            _print_trades(
+                best.result,
+                title=f"1h {best.name} {best.exit_mode} BUY/SHORT (after charges, tax excluded)",
             )
 
     out = Path(args.out_dir)

--- a/goldpetal/backtest_ohlcv_lab.py
+++ b/goldpetal/backtest_ohlcv_lab.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""OHLCV Strategy Laboratory backtest — research only. Not paper. Not live.
+
+Seven OHLCV strategies × two exits (flip+EOD, 2ATR/1.5ATR trail), ranked
+after Angel charges (tax excluded) by expectancy / profit factor /
+drawdown / walk-forward. Win rate is printed last on purpose.
+
+  ./venv/bin/python backtest_ohlcv_lab.py --csv /tmp/goldpetal_1h_upstox.csv \\
+      --csv-30m /tmp/goldpetal_30m_upstox.csv --lots 100 --fees
+  ./venv/bin/python backtest_ohlcv_lab.py --db data/ticks.db --lots 100 --session --fees
+  ./venv/bin/python backtest_ohlcv_lab.py --from-angel --from 2026-08-02 --lots 100 --fees
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from backtest_hhhl_candles import Candle, Trade, print_by_day, write_outputs
+from s16_hhhl_wick import simulate_s16
+from s18_ohlc_vol_htf import VolBar, build_vol_bars, load_vol_rows, simulate_s18
+from s19_body_close import hours_from_ohlc
+from s20_fade_hl import aggregate_candles
+from ohlcv_lab import (
+    EXIT_ATR,
+    EXIT_FLIP,
+    FORMULA,
+    LAB_NAME,
+    STRATEGIES,
+    LabMetrics,
+    after_charges_inr,
+    run_lab_book,
+    session_bars,
+    trade_after_charges,
+)
+
+IST = ZoneInfo("Asia/Kolkata")
+MIN_TRADES = 20
+
+
+def _days_from_hours(hours: list[VolBar]) -> list[VolBar]:
+    candles = [Candle(b.time, b.open, b.high, b.low, b.close) for b in hours]
+    days = aggregate_candles(candles, 1440)
+    by_t = {c.time[:10]: 0.0 for c in days}
+    for b in hours:
+        by_t[b.day] = by_t.get(b.day, 0.0) + float(b.volume)
+    return [
+        VolBar(c.time, c.open, c.high, c.low, c.close, by_t.get(c.time[:10], 0.0))
+        for c in days
+    ]
+
+
+def _load_angel(date_from: str, date_to: str) -> tuple[list[VolBar], list[VolBar], str]:
+    from auth import login
+    from explain_s14_candles import (
+        bar_is_finished,
+        fetch_angel_candles,
+        in_session_dt,
+        parse_bar_ts,
+        reexec_with_bot_python,
+    )
+    from symbols import find_goldpetal_futures
+
+    reexec_with_bot_python()
+    start = datetime.strptime(date_from, "%Y-%m-%d").replace(tzinfo=IST)
+    if date_to:
+        end = datetime.strptime(date_to, "%Y-%m-%d").replace(
+            hour=23, minute=30, tzinfo=IST
+        )
+    else:
+        end = datetime.now(IST)
+    contract = find_goldpetal_futures()
+    token = str(contract["token"])
+    symbol = str(contract["symbol"])
+    print(
+        f"contract {symbol} token={token} expiry={contract.get('expiry', '-')}",
+        flush=True,
+    )
+    api = login().api
+    now = datetime.now(IST)
+    exch = str(contract.get("exchange") or "MCX")
+    raw_h = fetch_angel_candles(
+        api, token=token, interval="ONE_HOUR", start=start, end=end, exchange=exch
+    )
+    raw_d = fetch_angel_candles(
+        api, token=token, interval="ONE_DAY", start=start, end=end, exchange=exch
+    )
+    raw_h = [
+        b
+        for b in raw_h
+        if in_session_dt(parse_bar_ts(b["time"]), tf="1h")
+        and bar_is_finished(b["time"], "1h", now)
+    ]
+    raw_d = [b for b in raw_d if bar_is_finished(b["time"], "1d", now)]
+    return hours_from_ohlc(raw_h), hours_from_ohlc(raw_d), f"Angel {symbol}"
+
+
+def _fmt(m: LabMetrics) -> str:
+    return (
+        f"{m.name:12} {m.family:9} {m.exit_mode:8} "
+        f"n={m.n_trades:4d} L/S={m.n_long}/{m.n_short} "
+        f"AC₹={m.after_charges:10.1f} exp₹={m.expectancy:8.1f} "
+        f"PF={m.profit_factor:5.2f} avgW₹={m.avg_win:8.1f} avgL₹={m.avg_loss:8.1f} "
+        f"DDac₹={m.max_dd:10.1f} wf={m.stability:>4} "
+        f"wr%={100.0 * m.win_rate:5.1f}"
+    )
+
+
+def _print_table(title: str, rows: list[LabMetrics]) -> None:
+    print()
+    print(title)
+    print(
+        f"{'name':12} {'family':9} {'exit':8} {'n':>5} {'L/S':>7} "
+        f"{'after_charges₹':>14} {'exp₹':>9} {'PF':>6} {'avgW₹':>9} {'avgL₹':>9} "
+        f"{'DDac₹':>10} {'wf':>4} {'wr%':>6}"
+    )
+    ranked = sorted(rows, key=lambda m: m.after_charges, reverse=True)
+    for m in ranked:
+        print(
+            f"{m.name:12} {m.family:9} {m.exit_mode:8} {m.n_trades:5d} "
+            f"{m.n_long:3d}/{m.n_short:<3d} {m.after_charges:14.1f} "
+            f"{m.expectancy:9.1f} {m.profit_factor:6.2f} {m.avg_win:9.1f} "
+            f"{m.avg_loss:9.1f} {m.max_dd:10.1f} {m.stability:>4} "
+            f"{100.0 * m.win_rate:6.1f}"
+        )
+    print("Rank column is after_charges ₹ (tax excluded). wr% is last on purpose.")
+
+
+def _write_lab_trades(out_dir: Path, rows: list[LabMetrics]) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    board = out_dir / "scoreboard.csv"
+    with board.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(
+            f,
+            fieldnames=[
+                "name",
+                "family",
+                "exit_mode",
+                "n_trades",
+                "n_long",
+                "n_short",
+                "after_charges",
+                "expectancy",
+                "profit_factor",
+                "avg_win",
+                "avg_loss",
+                "max_dd_after_charges",
+                "walk_forward",
+                "win_rate",
+            ],
+        )
+        w.writeheader()
+        for m in rows:
+            w.writerow(
+                {
+                    "name": m.name,
+                    "family": m.family,
+                    "exit_mode": m.exit_mode,
+                    "n_trades": m.n_trades,
+                    "n_long": m.n_long,
+                    "n_short": m.n_short,
+                    "after_charges": f"{m.after_charges:.2f}",
+                    "expectancy": f"{m.expectancy:.2f}",
+                    "profit_factor": f"{m.profit_factor:.4f}",
+                    "avg_win": f"{m.avg_win:.2f}",
+                    "avg_loss": f"{m.avg_loss:.2f}",
+                    "max_dd_after_charges": f"{m.max_dd:.2f}",
+                    "walk_forward": m.stability,
+                    "win_rate": f"{m.win_rate:.4f}",
+                }
+            )
+    for m in rows:
+        if m.result is None:
+            continue
+        path = out_dir / f"trades_{m.result.tf}.csv"
+        with path.open("w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(
+                f,
+                fieldnames=[
+                    "tf",
+                    "signal",
+                    "side",
+                    "entry_time",
+                    "entry_px",
+                    "exit_time",
+                    "exit_px",
+                    "gross_pts",
+                    "gross_pnl_inr",
+                    "fees_inr",
+                    "after_charges_inr",
+                    "after_tax_pnl_inr",
+                    "lots",
+                ],
+            )
+            w.writeheader()
+            t: Trade
+            for t in m.result.trades:
+                w.writerow(
+                    {
+                        "tf": t.tf,
+                        "signal": "BUY" if t.side == "LONG" else "SHORT",
+                        "side": t.side,
+                        "entry_time": t.entry_time,
+                        "entry_px": t.entry_px,
+                        "exit_time": t.exit_time,
+                        "exit_px": t.exit_px,
+                        "gross_pts": t.gross_pts,
+                        "gross_pnl_inr": t.gross_pnl_inr,
+                        "fees_inr": t.fees_inr,
+                        "after_charges_inr": trade_after_charges(t),
+                        "after_tax_pnl_inr": t.after_tax_pnl_inr,
+                        "lots": t.lots,
+                    }
+                )
+
+
+def _baseline_s16(hours: list[VolBar], *, tf: str, lots: float, fees: bool) -> LabMetrics:
+    candles = [Candle(b.time, b.open, b.high, b.low, b.close) for b in hours]
+    res = simulate_s16(
+        candles,
+        tf=tf,
+        lots=lots,
+        fees=fees,
+        session_filter=True,
+        min_wick_gap=0.0,
+    )
+    return LabMetrics(
+        name="S16",
+        family="paper",
+        exit_mode="flip_eod",
+        n_trades=res.n_trades,
+        n_long=res.n_long,
+        n_short=res.n_short,
+        after_charges=after_charges_inr(res),
+        expectancy=(after_charges_inr(res) / res.n_trades) if res.n_trades else 0.0,
+        profit_factor=0.0,
+        avg_win=0.0,
+        avg_loss=0.0,
+        max_dd=0.0,
+        win_rate=0.0,
+        result=res,
+    )
+
+
+def _fill_trade_stats(m: LabMetrics) -> LabMetrics:
+    from ohlcv_lab import score_result
+
+    if m.result is None:
+        return m
+    return score_result(
+        m.result,
+        name=m.name,
+        family=m.family,
+        exit_mode=m.exit_mode,
+        wf_wins=m.wf_wins,
+        wf_folds=m.wf_folds,
+    )
+
+
+def _run_tf(
+    bars: list[VolBar],
+    *,
+    tf: str,
+    lots: float,
+    fees: bool,
+    n_folds: int,
+) -> list[LabMetrics]:
+    rows: list[LabMetrics] = []
+    kw = dict(lots=lots, fees=fees, flatten_eod=True)
+    for name, family, _idea in STRATEGIES:
+        for exit_mode in (EXIT_FLIP, EXIT_ATR):
+            m = run_lab_book(
+                bars,
+                name,
+                exit_mode=exit_mode,
+                family=family,
+                n_folds=n_folds,
+                tf=f"{tf}:{name}:{exit_mode}",
+                **kw,
+            )
+            rows.append(m)
+    return rows
+
+
+def _verdict(lab_rows: list[LabMetrics], s16: LabMetrics, s18: LabMetrics | None) -> str:
+    s16_ac = s16.after_charges
+    s18_ac = s18.after_charges if s18 is not None else None
+    beat: list[LabMetrics] = []
+    for m in lab_rows:
+        if m.n_trades < MIN_TRADES:
+            continue
+        if m.after_charges <= s16_ac:
+            continue
+        if s18_ac is not None and m.after_charges <= s18_ac:
+            continue
+        beat.append(m)
+    if not beat:
+        extra = (
+            f"S16 AC₹={s16_ac:.1f}"
+            + (f" S18 AC₹={s18_ac:.1f}" if s18_ac is not None else "")
+        )
+        return (
+            f"No lab book beats S16"
+            + (" and S18" if s18 is not None else "")
+            + f" after charges with ≥{MIN_TRADES} trades ({extra}). "
+            "Research only. Do not paper. Do not ENABLE."
+        )
+    names = ", ".join(f"{m.name}/{m.exit_mode} AC₹={m.after_charges:.1f}" for m in beat)
+    return (
+        f"Lab beat S16"
+        + (" and S18" if s18 is not None else "")
+        + f" after charges (≥{MIN_TRADES} trades): {names}. "
+        "Still research — do not ENABLE unless the operator asks to paper it."
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--db", default="data/ticks.db")
+    ap.add_argument("--from-angel", action="store_true")
+    ap.add_argument("--csv", type=Path, default=None)
+    ap.add_argument("--csv-30m", type=Path, default=None)
+    ap.add_argument("--from", dest="date_from", default="2026-08-02")
+    ap.add_argument("--to", dest="date_to", default="")
+    ap.add_argument("--lots", type=float, default=100.0)
+    ap.add_argument("--fees", action="store_true", default=True)
+    ap.add_argument("--no-fees", action="store_true")
+    ap.add_argument("--session", action="store_true", default=True)
+    ap.add_argument("--no-session", action="store_true")
+    ap.add_argument("--folds", type=int, default=3)
+    ap.add_argument("--out-dir", default="data/backtests/ohlcv_lab")
+    args = ap.parse_args()
+    fees = bool(args.fees) and not bool(args.no_fees)
+    session_filter = bool(args.session) and not bool(args.no_session)
+
+    m30: list[VolBar] = []
+    days: list[VolBar] = []
+    if args.from_angel:
+        hours, days, source = _load_angel(args.date_from, args.date_to)
+    elif args.csv:
+        with args.csv.open(newline="") as f:
+            hours = hours_from_ohlc(list(csv.DictReader(f)))
+        days = _days_from_hours(hours)
+        source = str(args.csv)
+        if args.csv_30m:
+            with args.csv_30m.open(newline="") as f:
+                m30 = hours_from_ohlc(list(csv.DictReader(f)))
+    else:
+        db = Path(args.db)
+        rows = load_vol_rows(db)
+        hours = build_vol_bars(rows, 60)
+        days = build_vol_bars(rows, 1440)
+        m30 = build_vol_bars(rows, 30)
+        source = f"ticks {db} n={len(rows)}"
+
+    if session_filter:
+        hours = session_bars(hours)
+        m30 = session_bars(m30) if m30 else m30
+
+    if len(hours) < 25:
+        raise SystemExit(f"need ≥25 1h bars, got {len(hours)} from {source}")
+
+    print(LAB_NAME, "(research — not a paper book, not live)")
+    print(FORMULA)
+    for name, family, idea in STRATEGIES:
+        print(f"  {name:10} [{family}] {idea}")
+    print(
+        f"lots={args.lots:g} fees={fees} session={session_filter} "
+        f"hours={len(hours)} {hours[0].time}→{hours[-1].time} "
+        f"30m={len(m30)} days={len(days)} folds={args.folds} source={source}",
+        flush=True,
+    )
+
+    kw_base = dict(lots=float(args.lots), fees=fees, n_folds=int(args.folds))
+    lab_1h = _run_tf(hours, tf="1h", **kw_base)
+    s16_1h = _fill_trade_stats(
+        _baseline_s16(hours, tf="1h:S16", lots=float(args.lots), fees=fees)
+    )
+    s18_1h: LabMetrics | None = None
+    has_vol = any(b.volume > 0 for b in hours)
+    if has_vol and days:
+        res18 = simulate_s18(
+            hours,
+            days,
+            tf="1h:S18",
+            lots=float(args.lots),
+            fees=fees,
+            session_filter=True,
+        )
+        s18_1h = _fill_trade_stats(
+            LabMetrics(
+                name="S18",
+                family="paper",
+                exit_mode="flip_eod",
+                n_trades=res18.n_trades,
+                n_long=res18.n_long,
+                n_short=res18.n_short,
+                after_charges=after_charges_inr(res18),
+                expectancy=0.0,
+                profit_factor=0.0,
+                avg_win=0.0,
+                avg_loss=0.0,
+                max_dd=0.0,
+                win_rate=0.0,
+                result=res18,
+            )
+        )
+
+    _print_table(
+        "1h OHLCV lab vs S16/S18  (after charges, tax excluded)",
+        lab_1h + [s16_1h] + ([s18_1h] if s18_1h is not None else []),
+    )
+    print(_verdict(lab_1h, s16_1h, s18_1h))
+
+    all_rows = list(lab_1h) + [s16_1h]
+    if s18_1h is not None:
+        all_rows.append(s18_1h)
+
+    if m30:
+        lab_30 = _run_tf(m30, tf="30m", **kw_base)
+        s16_30 = _fill_trade_stats(
+            _baseline_s16(m30, tf="30m:S16", lots=float(args.lots), fees=fees)
+        )
+        _print_table(
+            "30m OHLCV lab vs S16  (after charges, tax excluded)",
+            lab_30 + [s16_30],
+        )
+        print(_verdict(lab_30, s16_30, None))
+        all_rows.extend(lab_30)
+        all_rows.append(s16_30)
+
+    best = max(lab_1h, key=lambda m: m.after_charges)
+    if best.result is not None and best.result.trades:
+        print()
+        print(
+            f"Trade-by-trade for best 1h lab row {best.name}/{best.exit_mode} "
+            f"(BUY=LONG, SHORT=SHORT). Full CSVs under {args.out_dir}."
+        )
+        print_by_day([best.result])
+        # print each BUY/SHORT line for the best book
+        print("entry_time            signal  entry      exit_time            exit       AC₹")
+        for t in best.result.trades:
+            sig = "BUY  " if t.side == "LONG" else "SHORT"
+            print(
+                f"{t.entry_time}  {sig}  {t.entry_px:8.1f}  "
+                f"{t.exit_time}  {t.exit_px:8.1f}  {trade_after_charges(t):10.1f}"
+            )
+
+    out = Path(args.out_dir)
+    results = [m.result for m in all_rows if m.result is not None]
+    write_outputs(results, out)
+    _write_lab_trades(out, all_rows)
+    print(f"wrote {out}")
+    print(
+        "Stay DRY_RUN. Paper 100 lots is not live. OHLCV lab is research-only: "
+        "not on the desk, not ENABLE_*, not a paper book."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/goldpetal/backtest_ohlcv_lab.py
+++ b/goldpetal/backtest_ohlcv_lab.py
@@ -291,7 +291,7 @@ def _verdict(lab_rows: list[LabMetrics], s16: LabMetrics, s18: LabMetrics | None
     s18_ac = s18.after_charges if s18 is not None else None
     beat: list[LabMetrics] = []
     for m in lab_rows:
-        if m.n_trades < MIN_TRADES:
+        if m.n_trades < MIN_TRADES or m.after_charges <= 0:
             continue
         if m.after_charges <= s16_ac:
             continue
@@ -430,6 +430,10 @@ def main() -> None:
             lab_30 + [s16_30],
         )
         print(_verdict(lab_30, s16_30, None))
+        print(
+            "30m S16 is a research baseline on 30m bars, not the paper 1h S16 book. "
+            "Paper rank is the 1h table vs S16 and S18."
+        )
         all_rows.extend(lab_30)
         all_rows.append(s16_30)
 

--- a/goldpetal/backtest_ohlcv_lab.py
+++ b/goldpetal/backtest_ohlcv_lab.py
@@ -344,12 +344,28 @@ def _print_one(
         print()
         print("1h 2ATR target / 1.5ATR trail:")
         print(" ", _fmt(atr))
+        if atr.wf_rows:
+            for i, fold in enumerate(atr.wf_rows, 1):
+                print(
+                    f"    walk-forward fold {i}: n={fold.n_trades} "
+                    f"AC₹={fold.after_charges:.1f} exp₹={fold.expectancy:.1f} "
+                    f"PF={fold.profit_factor:.2f} wr%={100.0 * fold.win_rate:.1f}"
+                )
         print(" ", _book_verdict(atr, s16, s18))
+        if atr.result is not None:
+            _print_trades(
+                atr.result,
+                title=f"1h {name} ATR BUY/SHORT (after charges, tax excluded)",
+            )
     m30_flip = next((m for m in rows_30 if m.name == name and m.exit_mode == EXIT_FLIP), None)
+    m30_atr = next((m for m in rows_30 if m.name == name and m.exit_mode == EXIT_ATR), None)
     if m30_flip is not None:
         print()
         print("30m flip+EOD (research baseline, not the paper 1h books):")
         print(" ", _fmt(m30_flip))
+    if m30_atr is not None:
+        print("30m 2ATR / 1.5ATR trail (research baseline):")
+        print(" ", _fmt(m30_atr))
 
 
 def _run_tf(

--- a/goldpetal/ohlcv_lab.py
+++ b/goldpetal/ohlcv_lab.py
@@ -102,6 +102,7 @@ class LabMetrics:
     wf_folds: int = 0
     n_bars: int = 0
     result: Any = None
+    wf_rows: list[LabMetrics] | None = None
 
     @property
     def stability(self) -> str:
@@ -707,6 +708,23 @@ def walk_forward(
     return rows, wins, len(rows)
 
 
+def selected_strategies(names: list[str] | None) -> tuple[tuple[str, str, str], ...]:
+    """Filter STRATEGIES, keeping lab order (breakout → … → three)."""
+    if not names:
+        return STRATEGIES
+    want: list[str] = []
+    for item in names:
+        want.extend(x.strip() for x in str(item).split(",") if x.strip())
+    known = {row[0] for row in STRATEGIES}
+    unknown = [n for n in want if n not in known]
+    if unknown:
+        raise ValueError(
+            f"unknown lab strategy {unknown!r}; choose from {[n for n, _, _ in STRATEGIES]}"
+        )
+    pick = set(want)
+    return tuple(row for row in STRATEGIES if row[0] in pick)
+
+
 def run_lab_book(
     bars: list[VolBar],
     strategy: str,
@@ -719,11 +737,11 @@ def run_lab_book(
     sim_kwargs = {k: v for k, v in kwargs.items() if k != "n_folds"}
     res = simulate_lab(bars, strategy, exit_mode=exit_mode, **sim_kwargs)
     wf_kwargs = {k: v for k, v in sim_kwargs.items() if k not in {"tf", "entry_days"}}
-    _wf, wf_wins, wf_folds = walk_forward(
+    wf_rows, wf_wins, wf_folds = walk_forward(
         bars, strategy, exit_mode=exit_mode, n_folds=n_folds, **wf_kwargs
     )
     fam = family or next((f for n, f, _ in STRATEGIES if n == strategy), "")
-    return score_result(
+    metrics = score_result(
         res,
         name=strategy,
         family=fam,
@@ -731,3 +749,5 @@ def run_lab_book(
         wf_wins=wf_wins,
         wf_folds=wf_folds,
     )
+    metrics.wf_rows = wf_rows
+    return metrics

--- a/goldpetal/ohlcv_lab.py
+++ b/goldpetal/ohlcv_lab.py
@@ -1,0 +1,733 @@
+"""OHLCV Strategy Laboratory — research only. Not a paper book. Not live.
+
+Feed finished bars (OHLC + volume) through a feature pass (price action,
+volume, volatility), then seven named strategies, then a shared backtest
+with two exit modes. Rank after Angel charges, tax excluded:
+
+    expectancy + profit factor + after-charges drawdown + walk-forward
+    stability. Win rate is secondary (40% × large winners can beat 70% ×
+    small winners).
+
+Fill at the signal bar's close. ATR targets also exit at close — we do
+not fill the intra-bar high/low (that is look-ahead). Intraday tapes
+flatten at the last bar of each calendar day.
+
+Do not add these names to ALL_STRATEGY_NAMES / desk / ENABLE_*. Paper
+them only if a later tape beats S16 and S18 after charges with enough
+trades and the operator asks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from backtest_hhhl_candles import Candle, Trade, in_session, make_charge_cfg
+from backtest_wick_candles import _tf_result_from_trades
+from charges import ChargeConfig
+from s18_ohlc_vol_htf import VolBar, _close_leg
+
+LAB_NAME = "OHLCV_LAB"
+
+FORMULA = (
+    "Research lab, not a paper book. Finished OHLCV bars → features "
+    "(range, close location, RVOL, 20-bar high/low, ATR, session VWAP, SMA) → "
+    "seven strategies (volume breakout, climax reversal, pullback contraction, "
+    "consolidation breakout, VWAP+volume, RVOL momentum, three-candle) → "
+    "flip+EOD or 2ATR target / 1.5ATR trail. Fill at close. Rank after charges "
+    "(expectancy, profit factor, drawdown, walk-forward); win% secondary."
+)
+
+EXIT_FLIP = "flip_eod"
+EXIT_ATR = "atr"
+
+
+@dataclass(frozen=True)
+class LabParams:
+    lookback: int = 20
+    atr_n: int = 14
+    box: int = 12
+    breakout_rvol: float = 1.5
+    close_loc: float = 0.75
+    climax_rvol: float = 2.0
+    climax_range_mult: float = 1.5
+    impulse_rvol: float = 1.3
+    impulse_range_mult: float = 1.2
+    pullback_min: int = 2
+    pullback_max: int = 4
+    consol_range_frac: float = 0.7
+    consol_vol_frac: float = 0.85
+    consol_box_atr: float = 1.5
+    consol_rvol: float = 1.5
+    rvol_mom: float = 1.5
+    tp_atr: float = 2.0
+    trail_atr: float = 1.5
+
+
+@dataclass(frozen=True)
+class Feat:
+    rng: float
+    body: float
+    close_loc: float
+    green: bool
+    red: bool
+    avg_vol: float
+    rvol: float
+    avg_range: float
+    prev_high_n: float
+    prev_low_n: float
+    atr: float
+    sma: float
+    vwap: float
+    prev_close: float
+    prev_vol: float
+
+
+@dataclass
+class LabMetrics:
+    name: str
+    family: str
+    exit_mode: str
+    n_trades: int
+    n_long: int
+    n_short: int
+    after_charges: float
+    expectancy: float
+    profit_factor: float
+    avg_win: float
+    avg_loss: float
+    max_dd: float
+    win_rate: float
+    wf_wins: int = 0
+    wf_folds: int = 0
+    n_bars: int = 0
+    result: Any = None
+
+    @property
+    def stability(self) -> str:
+        if self.wf_folds <= 0:
+            return "—"
+        return f"{self.wf_wins}/{self.wf_folds}"
+
+
+# name, family, one-line idea
+STRATEGIES: tuple[tuple[str, str, str], ...] = (
+    ("breakout", "breakout", "Volume-confirmed breakout of the prior 20-bar high/low"),
+    ("climax", "reversal", "Extreme-volume climax, then fade the next bar's recovery"),
+    ("pullback", "trend", "Impulse then 2–4 weak-volume pullback bars, then resume"),
+    ("consol", "breakout", "Tight range + contracted volume, then expansion break"),
+    ("vwap", "trend", "Intraday VWAP pullback with volume confirmation"),
+    ("rvol_mom", "trend", "RVOL > 1.5 with close momentum near the bar extreme"),
+    ("three", "trend", "Strong candle, small pullback, breakout with rising volume"),
+)
+
+
+def rvol_class(rvol: float) -> str:
+    if rvol < 0.7:
+        return "low"
+    if rvol < 1.3:
+        return "normal"
+    if rvol < 2.0:
+        return "high"
+    return "extreme"
+
+
+def after_charges_inr(result: Any) -> float:
+    """Gross minus Angel charges. Tax excluded."""
+    return float(result.gross_pnl_inr) - float(result.fees_inr)
+
+
+def session_bars(
+    bars: list[VolBar],
+    *,
+    market_open: str = "09:00",
+    market_close: str = "23:30",
+) -> list[VolBar]:
+    """Keep MCX session bars so a 20-bar lookback is 20 session candles."""
+    out: list[VolBar] = []
+    for b in bars:
+        if in_session(
+            Candle(b.time, b.open, b.high, b.low, b.close),
+            open_hhmm=market_open,
+            close_hhmm=market_close,
+        ):
+            out.append(b)
+    return out
+
+
+def _close_loc(high: float, low: float, close: float) -> float:
+    rng = float(high) - float(low)
+    if rng <= 1e-12:
+        return 0.5
+    return (float(close) - float(low)) / rng
+
+
+def build_features(bars: list[VolBar], params: LabParams | None = None) -> list[Feat | None]:
+    p = params or LabParams()
+    n = len(bars)
+    n_lb = max(1, int(p.lookback))
+    n_atr = max(1, int(p.atr_n))
+    out: list[Feat | None] = [None] * n
+    if n < 2:
+        return out
+
+    trs = [0.0] * n
+    for i in range(1, n):
+        h, l, pc = bars[i].high, bars[i].low, bars[i - 1].close
+        trs[i] = max(h - l, abs(h - pc), abs(l - pc))
+    atrs = [0.0] * n
+    atr_ready = [False] * n
+    if n > n_atr:
+        atrs[n_atr] = sum(trs[1 : n_atr + 1]) / float(n_atr)
+        atr_ready[n_atr] = True
+        for i in range(n_atr + 1, n):
+            atrs[i] = (atrs[i - 1] * (n_atr - 1) + trs[i]) / float(n_atr)
+            atr_ready[i] = True
+
+    cum_tpv = 0.0
+    cum_vol = 0.0
+    prev_day = ""
+    for i, b in enumerate(bars):
+        if b.day != prev_day:
+            cum_tpv = 0.0
+            cum_vol = 0.0
+            prev_day = b.day
+        typical = (b.high + b.low + b.close) / 3.0
+        cum_tpv += typical * float(b.volume)
+        cum_vol += float(b.volume)
+        vwap = (cum_tpv / cum_vol) if cum_vol > 1e-12 else b.close
+        if i < n_lb or not atr_ready[i]:
+            continue
+        window = bars[i - n_lb : i]
+        avg_vol = sum(x.volume for x in window) / float(n_lb)
+        avg_range = sum((x.high - x.low) for x in window) / float(n_lb)
+        rvol = (float(b.volume) / avg_vol) if avg_vol > 1e-12 else 0.0
+        sma = sum(x.close for x in bars[i - n_lb + 1 : i + 1]) / float(n_lb)
+        rng = float(b.high) - float(b.low)
+        out[i] = Feat(
+            rng=rng,
+            body=abs(float(b.close) - float(b.open)),
+            close_loc=_close_loc(b.high, b.low, b.close),
+            green=b.close > b.open,
+            red=b.close < b.open,
+            avg_vol=avg_vol,
+            rvol=rvol,
+            avg_range=avg_range,
+            prev_high_n=max(x.high for x in window),
+            prev_low_n=min(x.low for x in window),
+            atr=atrs[i],
+            sma=sma,
+            vwap=vwap,
+            prev_close=bars[i - 1].close,
+            prev_vol=float(bars[i - 1].volume),
+        )
+    return out
+
+
+def decide_breakout(
+    bars: list[VolBar], feats: list[Feat | None], i: int, p: LabParams, st: dict[str, Any]
+) -> tuple[str | None, str]:
+    del st
+    f = feats[i]
+    if f is None:
+        return None, "warmup"
+    b = bars[i]
+    if b.close > f.prev_high_n and f.rvol >= p.breakout_rvol and f.close_loc >= p.close_loc:
+        return "long", "breakout:long C>Nhigh RVOL close-high"
+    if b.close < f.prev_low_n and f.rvol >= p.breakout_rvol and f.close_loc <= (1.0 - p.close_loc):
+        return "short", "breakout:short C<Nlow RVOL close-low"
+    return None, "breakout:no"
+
+
+def decide_climax(
+    bars: list[VolBar], feats: list[Feat | None], i: int, p: LabParams, st: dict[str, Any]
+) -> tuple[str | None, str]:
+    f = feats[i]
+    if f is None:
+        st["pending"] = None
+        return None, "warmup"
+    b = bars[i]
+    pending = st.get("pending")
+    signal: tuple[str | None, str] = (None, "climax:wait")
+    if pending is not None:
+        side, mid = pending
+        st["pending"] = None
+        if side == "long" and b.close > mid:
+            signal = ("long", "climax:long recover above midpoint")
+        elif side == "short" and b.close < mid:
+            signal = ("short", "climax:short reject below midpoint")
+        else:
+            signal = (None, "climax:no recover")
+        if signal[0] is not None:
+            return signal
+    large = f.rng >= p.climax_range_mult * f.avg_range and f.avg_range > 1e-12
+    if large and f.rvol >= p.climax_rvol and f.red and f.close_loc <= (1.0 - p.close_loc):
+        st["pending"] = ("long", (b.high + b.low) / 2.0)
+        return None, "climax:bearish setup wait"
+    if large and f.rvol >= p.climax_rvol and f.green and f.close_loc >= p.close_loc:
+        st["pending"] = ("short", (b.high + b.low) / 2.0)
+        return None, "climax:bullish setup wait"
+    return signal if pending is not None else (None, "climax:no")
+
+
+def _impulse_long(b: VolBar, f: Feat, p: LabParams) -> bool:
+    return (
+        f.green
+        and f.rvol >= p.impulse_rvol
+        and f.rng >= p.impulse_range_mult * f.avg_range
+        and b.close > f.sma
+        and f.body >= 0.5 * f.rng
+    )
+
+
+def _impulse_short(b: VolBar, f: Feat, p: LabParams) -> bool:
+    return (
+        f.red
+        and f.rvol >= p.impulse_rvol
+        and f.rng >= p.impulse_range_mult * f.avg_range
+        and b.close < f.sma
+        and f.body >= 0.5 * f.rng
+    )
+
+
+def decide_pullback(
+    bars: list[VolBar], feats: list[Feat | None], i: int, p: LabParams, st: dict[str, Any]
+) -> tuple[str | None, str]:
+    f = feats[i]
+    if f is None:
+        st["phase"] = None
+        return None, "warmup"
+    b = bars[i]
+    phase = st.get("phase")
+    impulse_vol = float(st.get("impulse_vol") or 0.0)
+    pb_count = int(st.get("pb_count") or 0)
+
+    def reset() -> None:
+        st["phase"] = None
+        st["impulse_vol"] = 0.0
+        st["pb_count"] = 0
+
+    def arm(side: str) -> None:
+        st["phase"] = side
+        st["impulse_vol"] = float(b.volume)
+        st["pb_count"] = 0
+
+    if phase == "long_pb":
+        if f.green and p.pullback_min <= pb_count <= p.pullback_max:
+            reset()
+            return "long", f"pullback:long after {pb_count} weak reds"
+        if f.red and float(b.volume) < impulse_vol and pb_count < p.pullback_max:
+            st["pb_count"] = pb_count + 1
+            return None, "pullback:long counting"
+        reset()
+        if _impulse_long(b, f, p):
+            arm("long_pb")
+            return None, "pullback:re-arm long"
+        if _impulse_short(b, f, p):
+            arm("short_pb")
+            return None, "pullback:re-arm short"
+        return None, "pullback:reset"
+    if phase == "short_pb":
+        if f.red and p.pullback_min <= pb_count <= p.pullback_max:
+            reset()
+            return "short", f"pullback:short after {pb_count} weak greens"
+        if f.green and float(b.volume) < impulse_vol and pb_count < p.pullback_max:
+            st["pb_count"] = pb_count + 1
+            return None, "pullback:short counting"
+        reset()
+        if _impulse_short(b, f, p):
+            arm("short_pb")
+            return None, "pullback:re-arm short"
+        if _impulse_long(b, f, p):
+            arm("long_pb")
+            return None, "pullback:re-arm long"
+        return None, "pullback:reset"
+    if _impulse_long(b, f, p):
+        arm("long_pb")
+        return None, "pullback:impulse long"
+    if _impulse_short(b, f, p):
+        arm("short_pb")
+        return None, "pullback:impulse short"
+    return None, "pullback:no"
+
+
+def decide_consol(
+    bars: list[VolBar], feats: list[Feat | None], i: int, p: LabParams, st: dict[str, Any]
+) -> tuple[str | None, str]:
+    del st
+    f = feats[i]
+    box = max(2, int(p.box))
+    if f is None or i < box:
+        return None, "warmup"
+    window = bars[i - box : i]
+    box_high = max(x.high for x in window)
+    box_low = min(x.low for x in window)
+    mean_range = sum((x.high - x.low) for x in window) / float(box)
+    mean_vol = sum(x.volume for x in window) / float(box)
+    width = box_high - box_low
+    tight = width <= p.consol_box_atr * f.atr and f.atr > 1e-12
+    quiet = mean_range <= p.consol_range_frac * f.avg_range and f.avg_range > 1e-12
+    dry = mean_vol <= p.consol_vol_frac * f.avg_vol and f.avg_vol > 1e-12
+    if not (tight and quiet and dry):
+        return None, "consol:not tight"
+    b = bars[i]
+    large = f.rng >= f.avg_range
+    if b.close > box_high and f.rvol >= p.consol_rvol and large:
+        return "long", "consol:long break high + volume"
+    if b.close < box_low and f.rvol >= p.consol_rvol and large:
+        return "short", "consol:short break low + volume"
+    return None, "consol:no break"
+
+
+def decide_vwap(
+    bars: list[VolBar], feats: list[Feat | None], i: int, p: LabParams, st: dict[str, Any]
+) -> tuple[str | None, str]:
+    del p, st
+    f = feats[i]
+    if f is None:
+        return None, "warmup"
+    b = bars[i]
+    if i == 0 or bars[i - 1].day != b.day:
+        return None, "vwap:first bar of day"
+    vol_up = float(b.volume) > f.prev_vol
+    if b.close > f.vwap and b.low <= f.vwap and f.green and vol_up:
+        return "long", "vwap:long pullback to VWAP vol-up"
+    if b.close < f.vwap and b.high >= f.vwap and f.red and vol_up:
+        return "short", "vwap:short pullback to VWAP vol-up"
+    return None, "vwap:no"
+
+
+def decide_rvol_mom(
+    bars: list[VolBar], feats: list[Feat | None], i: int, p: LabParams, st: dict[str, Any]
+) -> tuple[str | None, str]:
+    del st
+    f = feats[i]
+    if f is None:
+        return None, "warmup"
+    b = bars[i]
+    if (
+        f.rvol >= p.rvol_mom
+        and b.close > f.prev_close
+        and b.close > f.sma
+        and f.close_loc >= p.close_loc
+    ):
+        return "long", f"rvol_mom:long {rvol_class(f.rvol)}"
+    if (
+        f.rvol >= p.rvol_mom
+        and b.close < f.prev_close
+        and b.close < f.sma
+        and f.close_loc <= (1.0 - p.close_loc)
+    ):
+        return "short", f"rvol_mom:short {rvol_class(f.rvol)}"
+    return None, "rvol_mom:no"
+
+
+def decide_three(
+    bars: list[VolBar], feats: list[Feat | None], i: int, p: LabParams, st: dict[str, Any]
+) -> tuple[str | None, str]:
+    del p, st
+    if i < 2:
+        return None, "warmup"
+    f = feats[i]
+    f1 = feats[i - 2]
+    f2 = feats[i - 1]
+    if f is None or f1 is None or f2 is None:
+        return None, "warmup"
+    c1, c2, c3 = bars[i - 2], bars[i - 1], bars[i]
+    # Long: strong green, smaller pullback, break c1 high with rising volume
+    if (
+        f1.green
+        and f1.body >= 0.6 * f1.rng
+        and f1.rng > f1.avg_range
+        and f2.rng < f1.rng
+        and (f2.red or c2.close < c1.close)
+        and float(c2.volume) <= float(c1.volume) * 1.1
+        and f.green
+        and c3.close > c1.high
+        and float(c3.volume) > float(c2.volume)
+    ):
+        return "long", "three:long continuation"
+    if (
+        f1.red
+        and f1.body >= 0.6 * f1.rng
+        and f1.rng > f1.avg_range
+        and f2.rng < f1.rng
+        and (f2.green or c2.close > c1.close)
+        and float(c2.volume) <= float(c1.volume) * 1.1
+        and f.red
+        and c3.close < c1.low
+        and float(c3.volume) > float(c2.volume)
+    ):
+        return "short", "three:short continuation"
+    return None, "three:no"
+
+
+DECIDERS: dict[str, Callable[..., tuple[str | None, str]]] = {
+    "breakout": decide_breakout,
+    "climax": decide_climax,
+    "pullback": decide_pullback,
+    "consol": decide_consol,
+    "vwap": decide_vwap,
+    "rvol_mom": decide_rvol_mom,
+    "three": decide_three,
+}
+
+
+def _is_last_of_day(bars: list[VolBar], i: int) -> bool:
+    if i >= len(bars) - 1:
+        return True
+    return bars[i + 1].day != bars[i].day
+
+
+def simulate_lab(
+    bars: list[VolBar],
+    strategy: str,
+    *,
+    exit_mode: str = EXIT_FLIP,
+    tf: str | None = None,
+    lots: float = 100.0,
+    fees: bool = True,
+    flatten_eod: bool = True,
+    params: LabParams | None = None,
+    entry_days: set[str] | None = None,
+    charge_cfg: ChargeConfig | None = None,
+) -> Any:
+    """FLIP or ATR-exit simulator. Fill at close. Optional day window for WF."""
+    if strategy not in DECIDERS:
+        raise ValueError(f"unknown lab strategy {strategy!r}")
+    if exit_mode not in {EXIT_FLIP, EXIT_ATR}:
+        raise ValueError(f"unknown exit_mode {exit_mode!r}")
+    p = params or LabParams()
+    feats = build_features(bars, p)
+    decide = DECIDERS[strategy]
+    st: dict[str, Any] = {}
+    cfg = charge_cfg or make_charge_cfg(fees=fees, lots=lots)
+    book = tf or f"{strategy}:{exit_mode}"
+    trades: list[Trade] = []
+    side: str | None = None
+    entry_px = 0.0
+    entry_time = ""
+    entry_i = -1
+    entry_atr = 0.0
+    ext_px = 0.0
+
+    def close_trade(exit_c: VolBar) -> None:
+        nonlocal side, entry_px, entry_time
+        assert side is not None
+        trades.append(
+            _close_leg(
+                tf=book,
+                side=side,
+                entry_time=entry_time,
+                entry_px=entry_px,
+                exit_c=exit_c,
+                cfg=cfg,
+            )
+        )
+        side = None
+
+    def open_trade(cur: VolBar, want: str, atr: float, i: int) -> None:
+        nonlocal side, entry_px, entry_time, entry_i, entry_atr, ext_px
+        side = "LONG" if want == "long" else "SHORT"
+        entry_px = cur.close
+        entry_time = cur.time
+        entry_i = i
+        entry_atr = float(atr)
+        ext_px = cur.high if side == "LONG" else cur.low
+
+    for i, cur in enumerate(bars):
+        f = feats[i]
+        want, _why = decide(bars, feats, i, p, st) if f is not None else (None, "warmup")
+        scoring = entry_days is None or cur.day in entry_days
+        if not scoring:
+            if side is not None:
+                close_trade(cur)
+            continue
+        last = bool(flatten_eod) and _is_last_of_day(bars, i)
+        if last:
+            if side is not None:
+                close_trade(cur)
+            continue
+        if side is not None and exit_mode == EXIT_ATR and i > entry_i and f is not None:
+            ext_px = max(ext_px, cur.high) if side == "LONG" else min(ext_px, cur.low)
+            atr = entry_atr
+            if atr > 1e-12:
+                if side == "LONG":
+                    tp = entry_px + p.tp_atr * atr
+                    trail = ext_px - p.trail_atr * atr
+                    if cur.close >= tp or cur.close <= trail:
+                        close_trade(cur)
+                else:
+                    tp = entry_px - p.tp_atr * atr
+                    trail = ext_px + p.trail_atr * atr
+                    if cur.close <= tp or cur.close >= trail:
+                        close_trade(cur)
+        atr_now = float(f.atr) if f is not None else 0.0
+        if side == "LONG":
+            if want == "short":
+                close_trade(cur)
+                open_trade(cur, "short", atr_now, i)
+            continue
+        if side == "SHORT":
+            if want == "long":
+                close_trade(cur)
+                open_trade(cur, "long", atr_now, i)
+            continue
+        if want == "long":
+            open_trade(cur, "long", atr_now, i)
+        elif want == "short":
+            open_trade(cur, "short", atr_now, i)
+
+    if side is not None and bars:
+        close_trade(bars[-1])
+    if entry_days is not None:
+        trades = [t for t in trades if t.entry_time[:10] in entry_days]
+    return _tf_result_from_trades(book, len(bars), trades)
+
+
+def trade_after_charges(t: Trade) -> float:
+    return float(t.gross_pnl_inr) - float(t.fees_inr)
+
+
+def max_dd_after_charges(trades: list[Trade]) -> float:
+    equity = 0.0
+    peak = 0.0
+    dd = 0.0
+    for t in trades:
+        equity += trade_after_charges(t)
+        peak = max(peak, equity)
+        dd = max(dd, peak - equity)
+    return dd
+
+
+def profit_factor(trades: list[Trade]) -> float:
+    wins = sum(trade_after_charges(t) for t in trades if trade_after_charges(t) > 0)
+    losses = sum(trade_after_charges(t) for t in trades if trade_after_charges(t) < 0)
+    if losses >= -1e-12:
+        return 99.99 if wins > 1e-12 else 0.0
+    return wins / abs(losses)
+
+
+def score_result(
+    result: Any,
+    *,
+    name: str,
+    family: str = "",
+    exit_mode: str = EXIT_FLIP,
+    wf_wins: int = 0,
+    wf_folds: int = 0,
+) -> LabMetrics:
+    trades: list[Trade] = list(result.trades)
+    n = len(trades)
+    ac = after_charges_inr(result)
+    ac_list = [trade_after_charges(t) for t in trades]
+    win_acs = [x for x in ac_list if x > 0]
+    loss_acs = [x for x in ac_list if x < 0]
+    wr = (len(win_acs) / n) if n else 0.0
+    return LabMetrics(
+        name=name,
+        family=family,
+        exit_mode=exit_mode,
+        n_trades=n,
+        n_long=int(result.n_long),
+        n_short=int(result.n_short),
+        after_charges=ac,
+        expectancy=(ac / n) if n else 0.0,
+        profit_factor=profit_factor(trades),
+        avg_win=(sum(win_acs) / len(win_acs)) if win_acs else 0.0,
+        avg_loss=(sum(loss_acs) / len(loss_acs)) if loss_acs else 0.0,
+        max_dd=max_dd_after_charges(trades),
+        win_rate=wr,
+        wf_wins=wf_wins,
+        wf_folds=wf_folds,
+        n_bars=int(result.n_bars),
+        result=result,
+    )
+
+
+def unique_days(bars: list[VolBar]) -> list[str]:
+    out: list[str] = []
+    got: set[str] = set()
+    for b in bars:
+        if b.day not in got:
+            got.add(b.day)
+            out.append(b.day)
+    return out
+
+
+def day_folds(bars: list[VolBar], n_folds: int = 3) -> list[set[str]]:
+    days = unique_days(bars)
+    if not days:
+        return []
+    n_folds = max(1, int(n_folds))
+    if len(days) < n_folds:
+        return [set(days)]
+    folds: list[set[str]] = []
+    n = len(days)
+    for k in range(n_folds):
+        a = k * n // n_folds
+        b = (k + 1) * n // n_folds
+        folds.append(set(days[a:b]))
+    return folds
+
+
+def walk_forward(
+    bars: list[VolBar],
+    strategy: str,
+    *,
+    exit_mode: str = EXIT_FLIP,
+    n_folds: int = 3,
+    **kwargs: Any,
+) -> tuple[list[LabMetrics], int, int]:
+    """Score each chronological day-fold. Warmup bars before the fold update state."""
+    kwargs = {k: v for k, v in kwargs.items() if k not in {"tf", "entry_days"}}
+    folds = day_folds(bars, n_folds=n_folds)
+    rows: list[LabMetrics] = []
+    for i, days in enumerate(folds):
+        if not days:
+            continue
+        last = max(days)
+        window = [b for b in bars if b.day <= last]
+        res = simulate_lab(
+            window,
+            strategy,
+            exit_mode=exit_mode,
+            entry_days=days,
+            tf=f"{strategy}:{exit_mode}:wf{i + 1}",
+            **kwargs,
+        )
+        rows.append(
+            score_result(
+                res,
+                name=f"{strategy}:{exit_mode}:wf{i + 1}",
+                exit_mode=exit_mode,
+            )
+        )
+    wins = sum(1 for r in rows if r.after_charges > 0)
+    return rows, wins, len(rows)
+
+
+def run_lab_book(
+    bars: list[VolBar],
+    strategy: str,
+    *,
+    exit_mode: str = EXIT_FLIP,
+    family: str = "",
+    n_folds: int = 3,
+    **kwargs: Any,
+) -> LabMetrics:
+    sim_kwargs = {k: v for k, v in kwargs.items() if k != "n_folds"}
+    res = simulate_lab(bars, strategy, exit_mode=exit_mode, **sim_kwargs)
+    wf_kwargs = {k: v for k, v in sim_kwargs.items() if k not in {"tf", "entry_days"}}
+    _wf, wf_wins, wf_folds = walk_forward(
+        bars, strategy, exit_mode=exit_mode, n_folds=n_folds, **wf_kwargs
+    )
+    fam = family or next((f for n, f, _ in STRATEGIES if n == strategy), "")
+    return score_result(
+        res,
+        name=strategy,
+        family=fam,
+        exit_mode=exit_mode,
+        wf_wins=wf_wins,
+        wf_folds=wf_folds,
+    )

--- a/goldpetal/test_ohlcv_lab.py
+++ b/goldpetal/test_ohlcv_lab.py
@@ -26,6 +26,7 @@ from ohlcv_lab import (
     profit_factor,
     rvol_class,
     score_result,
+    selected_strategies,
     session_bars,
     simulate_lab,
     trade_after_charges,
@@ -59,6 +60,18 @@ def _series(
 
 
 P = LabParams(lookback=3, atr_n=2, box=3)
+
+
+def test_selected_strategies_order_and_filter() -> None:
+    assert selected_strategies(None) == STRATEGIES
+    picked = selected_strategies(["vwap", "breakout"])
+    assert [n for n, _, _ in picked] == ["breakout", "vwap"]
+    try:
+        selected_strategies(["nope"])
+    except ValueError as exc:
+        assert "unknown" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
 
 
 def test_rvol_class() -> None:
@@ -255,6 +268,7 @@ def test_not_wired_to_paper_or_live() -> None:
 
 
 if __name__ == "__main__":
+    test_selected_strategies_order_and_filter()
     test_rvol_class()
     test_breakout_long_and_short()
     test_breakout_skips_low_volume()

--- a/goldpetal/test_ohlcv_lab.py
+++ b/goldpetal/test_ohlcv_lab.py
@@ -1,0 +1,271 @@
+"""OHLCV Strategy Laboratory — research only. Not paper. Not live."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from control_state import ALL_STRATEGY_NAMES, SLIM_PAPER_STRATEGIES
+from live_readiness import PAPER_ONLY_BOOKS
+from ohlcv_lab import (
+    EXIT_ATR,
+    EXIT_FLIP,
+    LAB_NAME,
+    LabParams,
+    STRATEGIES,
+    after_charges_inr,
+    build_features,
+    decide_breakout,
+    decide_climax,
+    decide_consol,
+    decide_pullback,
+    decide_rvol_mom,
+    decide_three,
+    decide_vwap,
+    max_dd_after_charges,
+    profit_factor,
+    rvol_class,
+    score_result,
+    session_bars,
+    simulate_lab,
+    trade_after_charges,
+)
+from s18_ohlc_vol_htf import VolBar
+
+
+def _b(t: str, o: float, h: float, l: float, c: float, v: float = 100.0) -> VolBar:
+    return VolBar(t, o, h, l, c, v)
+
+
+def _series(
+    n: int,
+    *,
+    start: str = "2026-08-10 09:00:00",
+    px: float = 100.0,
+    rng: float = 2.0,
+    vol: float = 100.0,
+    step_hours: int = 1,
+) -> list[VolBar]:
+    t0 = datetime.strptime(start, "%Y-%m-%d %H:%M:%S")
+    bars: list[VolBar] = []
+    for i in range(n):
+        t = (t0 + timedelta(hours=step_hours * i)).strftime("%Y-%m-%d %H:%M:%S")
+        o = px
+        h = px + rng / 2.0
+        l = px - rng / 2.0
+        c = px
+        bars.append(_b(t, o, h, l, c, vol))
+    return bars
+
+
+P = LabParams(lookback=3, atr_n=2, box=3)
+
+
+def test_rvol_class() -> None:
+    assert rvol_class(0.4) == "low"
+    assert rvol_class(1.0) == "normal"
+    assert rvol_class(1.5) == "high"
+    assert rvol_class(2.5) == "extreme"
+
+
+def test_breakout_long_and_short() -> None:
+    bars = _series(3, px=100.0, rng=2.0, vol=100.0)
+    # prev 3-bar high is 101. Close 108, upper 25%, 2× volume.
+    bars.append(_b("2026-08-10 12:00:00", 100.0, 110.0, 100.0, 108.0, 200.0))
+    feats = build_features(bars, P)
+    st: dict = {}
+    side, why = decide_breakout(bars, feats, 3, P, st)
+    assert side == "long", why
+    bars_s = _series(3, px=100.0, rng=2.0, vol=100.0)
+    bars_s.append(_b("2026-08-10 12:00:00", 100.0, 100.0, 90.0, 92.0, 200.0))
+    feats_s = build_features(bars_s, P)
+    side_s, why_s = decide_breakout(bars_s, feats_s, 3, P, st)
+    assert side_s == "short", why_s
+
+
+def test_breakout_skips_low_volume() -> None:
+    bars = _series(3, px=100.0, rng=2.0, vol=100.0)
+    bars.append(_b("2026-08-10 12:00:00", 100.0, 110.0, 100.0, 108.0, 100.0))
+    feats = build_features(bars, P)
+    side, _ = decide_breakout(bars, feats, 3, P, {})
+    assert side is None
+
+
+def test_climax_waits_then_buys_recovery() -> None:
+    bars = _series(3, px=100.0, rng=2.0, vol=100.0)
+    # large bearish + 2× vol + close near low → do not short
+    bars.append(_b("2026-08-10 12:00:00", 110.0, 110.0, 90.0, 91.0, 250.0))
+    bars.append(_b("2026-08-10 13:00:00", 92.0, 108.0, 92.0, 106.0, 80.0))
+    feats = build_features(bars, P)
+    st: dict = {}
+    s0, w0 = decide_climax(bars, feats, 3, P, st)
+    assert s0 is None, w0
+    assert st.get("pending") is not None
+    s1, w1 = decide_climax(bars, feats, 4, P, st)
+    assert s1 == "long", w1
+    # do not chase the climax bar itself
+    st2: dict = {}
+    decide_climax(bars, feats, 3, P, st2)
+    assert st2["pending"][0] == "long"
+
+
+def test_pullback_long_after_weak_reds() -> None:
+    bars = _series(5, px=100.0, rng=2.0, vol=100.0)
+    # impulse green, large, high volume, close > SMA
+    bars.append(_b("2026-08-10 14:00:00", 100.0, 120.0, 99.0, 119.0, 200.0))
+    bars.append(_b("2026-08-10 15:00:00", 118.0, 118.0, 114.0, 115.0, 60.0))
+    bars.append(_b("2026-08-10 16:00:00", 115.0, 116.0, 112.0, 113.0, 50.0))
+    bars.append(_b("2026-08-10 17:00:00", 113.0, 118.0, 112.0, 117.0, 70.0))
+    p = LabParams(lookback=5, atr_n=2, box=3)
+    feats = build_features(bars, p)
+    st: dict = {}
+    sides = []
+    for i in range(len(bars)):
+        side, why = decide_pullback(bars, feats, i, p, st)
+        sides.append((i, side, why, st.get("phase"), st.get("pb_count")))
+    long_hits = [x for x in sides if x[1] == "long"]
+    assert long_hits, sides
+
+
+def test_consol_breakout() -> None:
+    bars = _series(6, px=100.0, rng=8.0, vol=200.0)
+    bars.append(_b("2026-08-10 15:00:00", 100.0, 100.6, 99.5, 100.1, 40.0))
+    bars.append(_b("2026-08-10 16:00:00", 100.1, 100.5, 99.6, 100.0, 35.0))
+    bars.append(_b("2026-08-10 17:00:00", 100.0, 100.4, 99.7, 100.0, 30.0))
+    bars.append(_b("2026-08-10 18:00:00", 100.0, 108.0, 99.8, 107.0, 400.0))
+    p = LabParams(lookback=6, atr_n=2, box=3)
+    feats = build_features(bars, p)
+    i = len(bars) - 1
+    side, why = decide_consol(bars, feats, i, p, {})
+    assert side == "long", (why, feats[i])
+
+
+def test_vwap_pullback_not_first_bar() -> None:
+    bars = [
+        _b("2026-08-17 09:00:00", 100.0, 120.0, 100.0, 120.0, 100.0),
+        _b("2026-08-17 10:00:00", 112.0, 116.0, 110.0, 115.0, 150.0),
+    ]
+    p = LabParams(lookback=1, atr_n=1)
+    feats = build_features(bars, p)
+    assert decide_vwap(bars, feats, 0, p, {})[0] is None
+    assert feats[1] is not None
+    side, why = decide_vwap(bars, feats, 1, p, {})
+    assert side == "long", (why, feats[1].vwap, bars[1].low, bars[1].close)
+
+
+def test_rvol_momentum_long() -> None:
+    bars = _series(4, px=100.0, rng=2.0, vol=100.0)
+    bars.append(_b("2026-08-10 13:00:00", 100.0, 112.0, 100.0, 111.0, 200.0))
+    p = LabParams(lookback=3, atr_n=2)
+    feats = build_features(bars, p)
+    side, why = decide_rvol_mom(bars, feats, 4, p, {})
+    assert side == "long", (why, feats[4])
+
+
+def test_three_candle_long() -> None:
+    bars = _series(4, px=100.0, rng=2.0, vol=100.0)
+    bars.append(_b("2026-08-10 13:00:00", 100.0, 110.0, 99.0, 109.0, 150.0))  # c1 strong
+    bars.append(_b("2026-08-10 14:00:00", 108.0, 109.0, 105.0, 106.0, 80.0))  # c2 pullback
+    bars.append(_b("2026-08-10 15:00:00", 106.0, 114.0, 105.0, 113.0, 160.0))  # c3 break
+    p = LabParams(lookback=3, atr_n=2)
+    feats = build_features(bars, p)
+    i = len(bars) - 1
+    side, why = decide_three(bars, feats, i, p, {})
+    assert side == "long", (why, feats[i - 2], feats[i])
+
+
+def test_flip_eod_and_atr_exits() -> None:
+    bars = _series(3, px=100.0, rng=2.0, vol=100.0)
+    bars.append(_b("2026-08-10 12:00:00", 100.0, 110.0, 100.0, 108.0, 200.0))  # long
+    bars.append(_b("2026-08-10 13:00:00", 108.0, 109.0, 107.0, 108.5, 80.0))
+    bars.append(_b("2026-08-11 09:00:00", 108.5, 109.0, 107.0, 108.0, 80.0))
+    r = simulate_lab(
+        bars, "breakout", params=P, lots=1.0, fees=False, flatten_eod=True, tf="t"
+    )
+    assert r.n_long == 1
+    assert r.trades[0].entry_px == 108.0
+    # flattened at last bar of 2026-08-10 (13:00), not on next day
+    assert r.trades[0].exit_time == "2026-08-10 13:00:00"
+
+    # ATR: freeze ATR at entry, exit at close when 2×ATR target prints on close
+    atr_bars = _series(3, px=100.0, rng=2.0, vol=100.0)
+    atr_bars.append(_b("2026-08-10 12:00:00", 100.0, 110.0, 100.0, 108.0, 200.0))
+    # huge close well beyond 2 ATR (ATR on these toys is a few pts)
+    atr_bars.append(_b("2026-08-10 13:00:00", 108.0, 140.0, 107.0, 139.0, 80.0))
+    atr_bars.append(_b("2026-08-10 14:00:00", 139.0, 140.0, 138.0, 139.0, 80.0))
+    r2 = simulate_lab(
+        atr_bars,
+        "breakout",
+        exit_mode=EXIT_ATR,
+        params=P,
+        lots=1.0,
+        fees=False,
+        flatten_eod=False,
+        tf="atr",
+    )
+    assert r2.n_long == 1
+    assert r2.trades[0].exit_px == 139.0
+    # honest fill is the close, not the 140 high
+    assert r2.trades[0].exit_px != 140.0
+
+
+def test_rank_metrics_use_after_charges_not_winrate() -> None:
+    bars = _series(3, px=100.0, rng=2.0, vol=100.0)
+    bars.append(_b("2026-08-10 12:00:00", 100.0, 110.0, 100.0, 108.0, 200.0))
+    bars.append(_b("2026-08-10 13:00:00", 108.0, 109.0, 90.0, 91.0, 80.0))
+    r = simulate_lab(
+        bars, "breakout", params=P, lots=100.0, fees=True, flatten_eod=False, tf="m"
+    )
+    m = score_result(r, name="breakout", family="breakout", exit_mode=EXIT_FLIP)
+    assert abs(m.after_charges - after_charges_inr(r)) < 1e-9
+    assert abs(m.after_charges - (r.gross_pnl_inr - r.fees_inr)) < 1e-9
+    assert m.after_charges >= r.after_tax_pnl_inr - 1e-9
+    assert abs(max_dd_after_charges(r.trades) - m.max_dd) < 1e-9
+    assert profit_factor(r.trades) >= 0.0
+    if r.trades:
+        assert abs(trade_after_charges(r.trades[0]) - (r.trades[0].gross_pnl_inr - r.trades[0].fees_inr)) < 1e-9
+
+
+def test_session_bars_drop_weekend() -> None:
+    bars = [
+        _b("2026-08-14 10:00:00", 100, 101, 99, 100, 10),  # Friday
+        _b("2026-08-15 10:00:00", 100, 101, 99, 100, 10),  # Saturday
+        _b("2026-08-17 10:00:00", 100, 101, 99, 100, 10),  # Monday
+    ]
+    out = session_bars(bars)
+    assert [b.time[:10] for b in out] == ["2026-08-14", "2026-08-17"]
+
+
+def test_not_wired_to_paper_or_live() -> None:
+    names = [n for n, _, _ in STRATEGIES]
+    for n in names + [LAB_NAME]:
+        assert n not in ALL_STRATEGY_NAMES
+        assert n not in SLIM_PAPER_STRATEGIES
+        assert n not in PAPER_ONLY_BOOKS
+    root = Path(__file__).resolve().parent
+    station = (root / "station.html").read_text(encoding="utf-8")
+    paper = station.split("const PAPER_BOOKS")[1].split("];")[0]
+    portfolio = (root / "portfolio.py").read_text(encoding="utf-8")
+    runner = (root / "run_strategy.py").read_text(encoding="utf-8")
+    assert "ENABLE_OHLCV" not in portfolio
+    assert "ohlcv_lab" not in runner
+    assert "breakout" not in paper or "OHLCV" not in paper
+    for n in names:
+        assert n not in ALL_STRATEGY_NAMES
+
+
+if __name__ == "__main__":
+    test_rvol_class()
+    test_breakout_long_and_short()
+    test_breakout_skips_low_volume()
+    test_climax_waits_then_buys_recovery()
+    test_pullback_long_after_weak_reds()
+    test_consol_breakout()
+    test_vwap_pullback_not_first_bar()
+    test_rvol_momentum_long()
+    test_three_candle_long()
+    test_flip_eod_and_atr_exits()
+    test_rank_metrics_use_after_charges_not_winrate()
+    test_session_bars_drop_weekend()
+    test_not_wired_to_paper_or_live()
+    print("ALL test_ohlcv_lab OK")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Research-only OHLCV Strategy Laboratory. It does **not** add a paper book, desk checkbox, or `ENABLE_*`. Stay `DRY_RUN`.

Each idea is testable **alone**:

```
./venv/bin/python backtest_ohlcv_lab.py --csv hours.csv --csv-30m 30m.csv --lots 100 --fees --one-by-one
./venv/bin/python backtest_ohlcv_lab.py --csv hours.csv --strategy vwap --strategy rvol_mom --one-by-one --lots 100 --fees
./venv/bin/python backtest_ohlcv_lab.py --db data/ticks.db --strategy vwap --strategy rvol_mom --one-by-one --lots 100 --fees
```

`--one-by-one` prints 1h flip+EOD **and** ATR BUY/SHORT rows, ATR walk-forward folds, 30m baseline, and a verdict vs S16/S18.

Fill is the **close**. Rank **after Angel charges, tax excluded**. Win rate is last on purpose.

### Tape

Upstox `GOLDPETAL26AUGFUT` (`MCX_FO|562056`), 100 lots + fees. 974 1h bars 2026-05-18 09:00 → 2026-08-17 23:00. Volume is **exchange bar volume**, not Angel websocket `volume_trade_for_the_day` delta. Cloud `ticks.db` is empty (0 ticks) and there is no Angel `.env` here — the tick-delta retest has to run on the VM with `--db data/ticks.db`. Paper baselines on the same hours: **S16 +₹41,070** (253 trades) and **S18 +₹2,55,889** (48 trades).

### Candidate retest (VWAP + RVOL-mom ATR)

These were the only 1h books with size and PF ≳ 1.5.

| Book | n | L/S | after_charges ₹ | exp ₹ | PF | DD ₹ | WF | vs S16 | vs S18 |
|---|---:|---|---:|---:|---:|---:|---|---|---|
| VWAP flip+EOD | 99 | 50/49 | **+1,70,025** | 1717 | 1.78 | 50,524 | 2/3 (−11k / +1.24L / +57k) | beat | lose |
| VWAP ATR | 105 | 54/51 | +92,284 | 879 | 1.41 | 55,939 | 2/3 (−24k / +66k / +50k) | beat | lose |
| RVOL-mom ATR | 47 | 16/31 | +87,075 | 1853 | 1.75 | 26,583 | **3/3** (+12k / +66k / +10k) | beat | lose |
| RVOL-mom flip+EOD | 38 | 13/25 | +83,154 | 2188 | 1.57 | 40,818 | 2/3 (−11k / +80k / +14k) | beat | lose |

ATR **does not** help VWAP (cuts +₹1.70L down to +₹92k, fold 1 worse). ATR **does** help RVOL-mom (all three folds green, smaller DD). Both still trail S18 by ₹85k–₹1.69L. 30m RVOL-mom ATR **loses** (−₹8,572). Do not paper. Do not ENABLE.

### Full seven (1h flip+EOD)

| # | Strategy | n | after_charges ₹ | PF | WF | paper? |
|---|---|---:|---:|---:|---|---|
| 1 | Volume breakout | 23 | +6,804 | 1.06 | 1/3 | no |
| 2 | Climax reversal | 4 | +9,446 | 1.79 | 2/3 | no (4 trades) |
| 3 | Pullback + contraction | 16 | +61,012 | 4.55 | 3/3 | no (16 trades; 30m −₹24k) |
| 4 | Consolidation break | 0 | 0 | — | 0/3 | no (never fired) |
| 5 | VWAP + volume | 99 | +1,70,025 | 1.78 | 2/3 | no (trails S18) |
| 6 | RVOL momentum | 38 | +83,154 | 1.57 | 2/3 | no (trails S18) |
| 7 | Three-candle | 8 | +19,351 | 1.66 | 2/3 | no (8 trades) |

**No book beats S16 and S18 after charges with ≥20 trades.**

### What this PR does not do

- Does not add these names to `ALL_STRATEGY_NAMES`, desk, or `ENABLE_*`
- Does not change S13/S16
- Does not live-unlock

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e92370bb-ed6a-433d-8b83-fe612227a4b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e92370bb-ed6a-433d-8b83-fe612227a4b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

